### PR TITLE
feat(deploy): push コマンド実装 — R2 差分アップロード + Pages Direct Upload + クリーンアップ

### DIFF
--- a/packages/deploy/package.json
+++ b/packages/deploy/package.json
@@ -11,28 +11,34 @@
       "import": "./dist/vite/plugin.js"
     }
   },
-  "files": ["dist"],
+  "files": [
+    "dist"
+  ],
   "scripts": {
     "build": "tsc",
     "dev": "tsc --watch",
     "test": "vitest run"
   },
   "dependencies": {
+    "@aws-sdk/client-s3": "^3.993.0",
+    "@aws-sdk/lib-storage": "^3.993.0",
     "@static3d/types": "workspace:*",
     "glob": "^11.0.0",
     "mime-types": "^2.1.35"
   },
   "devDependencies": {
+    "@types/mime-types": "^2.1.4",
+    "@types/node": "^22.0.0",
     "typescript": "^5.7.0",
     "vite": "^6.0.0",
-    "vitest": "^2.0.0",
-    "@types/mime-types": "^2.1.4",
-    "@types/node": "^22.0.0"
+    "vitest": "^2.0.0"
   },
   "peerDependencies": {
     "vite": "^5.0.0 || ^6.0.0"
   },
   "peerDependenciesMeta": {
-    "vite": { "optional": true }
+    "vite": {
+      "optional": true
+    }
   }
 }

--- a/packages/deploy/src/cli/build.ts
+++ b/packages/deploy/src/cli/build.ts
@@ -1,9 +1,13 @@
 import { loadConfig, validateDeployConfig } from '../config/schema.js';
 import { build } from '../build/index.js';
 
-export async function buildCommand(configPath?: string): Promise<void> {
+export interface BuildCommandOptions {
+  configPath?: string;
+}
+
+export async function buildCommand(opts: BuildCommandOptions = {}): Promise<void> {
   try {
-    const config = loadConfig(configPath);
+    const config = loadConfig(opts.configPath);
     const deployConfig = validateDeployConfig(config);
     await build(deployConfig);
   } catch (error) {

--- a/packages/deploy/src/cli/index.ts
+++ b/packages/deploy/src/cli/index.ts
@@ -1,6 +1,8 @@
 #!/usr/bin/env node
 
 import { buildCommand } from './build.js';
+import { pushCommand } from './push.js';
+import { validateCommand } from './validate.js';
 
 const args = process.argv.slice(2);
 const command = args[0];
@@ -10,30 +12,46 @@ const subCommand = args[1];
 const effectiveCommand =
   command === 'deploy' && subCommand ? subCommand : command;
 
-const configFlagIndex = args.indexOf('--config');
-const configPath =
-  configFlagIndex !== -1 ? args[configFlagIndex + 1] : undefined;
+// フラグパーサー
+function getFlag(flag: string): string | undefined {
+  const idx = args.indexOf(flag);
+  return idx !== -1 ? args[idx + 1] : undefined;
+}
+function hasFlag(flag: string): boolean {
+  return args.includes(flag);
+}
+
+const configPath = getFlag('--config');
+const projectName = getFlag('--project');
+const skipCleanup = hasFlag('--skip-cleanup');
+const skipPages = hasFlag('--skip-pages');
 
 switch (effectiveCommand) {
   case 'build':
-    buildCommand(configPath);
+    buildCommand({ configPath });
     break;
+
   case 'push':
-    console.log('[TODO] push command — Cloudflare R2 + Pages deploy');
+    pushCommand({ configPath, projectName, skipCleanup, skipPages });
     break;
+
   case 'validate':
-    console.log('[TODO] validate command');
+    validateCommand({ configPath });
     break;
+
   default:
     console.log(`
 static3d-deploy — Static 3D asset deployment tool
 
 Usage:
-  static3d-deploy build     Build assets (hash + manifest + gltf rewrite)
-  static3d-deploy push      Deploy to Cloudflare (R2 + Pages)  [TODO]
-  static3d-deploy validate  Validate config and assets          [TODO]
+  static3d-deploy build       Build assets (hash + manifest + gltf rewrite)
+  static3d-deploy push        Deploy to Cloudflare (R2 + Pages)
+  static3d-deploy validate    Validate config, assets, and env vars
 
 Options:
-  --config <path>  Path to static3d.config.json (default: ./static3d.config.json)
+  --config <path>      Path to static3d.config.json (default: ./static3d.config.json)
+  --project <name>     Cloudflare Pages project name (default: config.project)
+  --skip-cleanup       Skip old asset cleanup after push
+  --skip-pages         Skip Pages deploy, upload to R2 only
 `);
 }

--- a/packages/deploy/src/cli/push.ts
+++ b/packages/deploy/src/cli/push.ts
@@ -1,0 +1,34 @@
+import { loadConfig, validateDeployConfig } from '../config/schema.js';
+import { push } from '../push/index.js';
+
+export interface PushCommandOptions {
+  configPath?: string;
+  projectName?: string;
+  skipCleanup?: boolean;
+  skipPages?: boolean;
+}
+
+export async function pushCommand(opts: PushCommandOptions = {}): Promise<void> {
+  try {
+    const config = loadConfig(opts.configPath);
+    const deployConfig = validateDeployConfig(config);
+
+    const projectName = opts.projectName ?? config.project;
+    if (!projectName) {
+      console.error('[CONFIG] "project" is required in static3d.config.json');
+      process.exit(1);
+    }
+
+    await push(deployConfig, projectName, {
+      skipCleanup: opts.skipCleanup,
+      skipPages: opts.skipPages,
+    });
+  } catch (error) {
+    if (error instanceof Error) {
+      console.error(error.message);
+    } else {
+      console.error(String(error));
+    }
+    process.exit(1);
+  }
+}

--- a/packages/deploy/src/cli/validate.ts
+++ b/packages/deploy/src/cli/validate.ts
@@ -1,0 +1,129 @@
+import { loadConfig, validateDeployConfig } from '../config/schema.js';
+import { collectDeferredAssets } from '../build/collect.js';
+import { existsSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+export interface ValidateCommandOptions {
+  configPath?: string;
+}
+
+export async function validateCommand(
+  opts: ValidateCommandOptions = {}
+): Promise<void> {
+  let hasError = false;
+
+  const log = {
+    ok: (msg: string) => console.log(`  ✓ ${msg}`),
+    warn: (msg: string) => console.warn(`  ⚠ ${msg}`),
+    err: (msg: string) => {
+      console.error(`  ✗ ${msg}`);
+      hasError = true;
+    },
+  };
+
+  console.log('[VALIDATE] Checking static3d.config.json...\n');
+
+  // --- config読み込み ---
+  let config;
+  try {
+    config = loadConfig(opts.configPath);
+    log.ok('Config file loaded');
+  } catch (e) {
+    log.err((e as Error).message);
+    process.exit(1);
+  }
+
+  // --- schemaVersion ---
+  if (config.schemaVersion !== 1) {
+    log.err(`schemaVersion must be 1, got ${config.schemaVersion}`);
+  } else {
+    log.ok(`schemaVersion: ${config.schemaVersion}`);
+  }
+
+  // --- project名 ---
+  if (!config.project) {
+    log.err('"project" is required');
+  } else {
+    log.ok(`project: "${config.project}"`);
+  }
+
+  // --- deploy section ---
+  if (!config.deploy) {
+    log.warn('"deploy" section not present — skipping deploy validation');
+  } else {
+    let deployConfig;
+    try {
+      deployConfig = validateDeployConfig(config);
+      log.ok('Deploy config valid');
+    } catch (e) {
+      log.err((e as Error).message);
+    }
+
+    if (deployConfig) {
+      // CDN baseUrl
+      if (deployConfig.cdn.baseUrl.startsWith('https://')) {
+        log.ok(`cdn.baseUrl: ${deployConfig.cdn.baseUrl}`);
+      } else {
+        log.err('cdn.baseUrl must start with https://');
+      }
+
+      // ディレクトリ存在確認
+      const immDir = resolve(deployConfig.assets.immediateDir);
+      const defDir = resolve(deployConfig.assets.deferredDir);
+
+      if (existsSync(immDir)) {
+        log.ok(`immediateDir exists: ${deployConfig.assets.immediateDir}`);
+      } else {
+        log.err(`immediateDir not found: ${deployConfig.assets.immediateDir}`);
+      }
+
+      if (existsSync(defDir)) {
+        log.ok(`deferredDir exists: ${deployConfig.assets.deferredDir}`);
+      } else {
+        log.err(`deferredDir not found: ${deployConfig.assets.deferredDir}`);
+      }
+
+      // アセット収集（実際にglobして確認）
+      if (existsSync(defDir)) {
+        try {
+          const assets = await collectDeferredAssets(deployConfig);
+          log.ok(`Deferred assets: ${assets.length} file(s) found`);
+
+          const gltfCount = assets.filter((a) => a.key.endsWith('.gltf')).length;
+          if (gltfCount > 0) {
+            log.ok(`  ${gltfCount} .gltf file(s) will be rewritten`);
+          }
+        } catch (e) {
+          log.err(`Asset collection failed: ${(e as Error).message}`);
+        }
+      }
+    }
+  }
+
+  // --- 環境変数チェック ---
+  console.log('\n[VALIDATE] Checking environment variables...\n');
+
+  const envVars = [
+    { name: 'CLOUDFLARE_ACCOUNT_ID', required: true },
+    { name: 'CLOUDFLARE_R2_ACCESS_KEY_ID', required: true },
+    { name: 'CLOUDFLARE_R2_SECRET_ACCESS_KEY', required: true },
+    { name: 'CLOUDFLARE_API_TOKEN', required: true },
+  ];
+
+  for (const { name, required } of envVars) {
+    if (process.env[name]) {
+      log.ok(`${name}: set`);
+    } else if (required) {
+      log.warn(`${name}: not set (required for "push" command)`);
+    }
+  }
+
+  // --- 結果 ---
+  console.log('');
+  if (hasError) {
+    console.error('[VALIDATE] ✗ Validation failed — fix errors above');
+    process.exit(1);
+  } else {
+    console.log('[VALIDATE] ✓ All checks passed');
+  }
+}

--- a/packages/deploy/src/config/auth.ts
+++ b/packages/deploy/src/config/auth.ts
@@ -1,0 +1,89 @@
+/**
+ * 認証情報の解決
+ *
+ * ## 2種類の認証情報について
+ *
+ * ### R2 S3互換キー (CLOUDFLARE_R2_ACCESS_KEY_ID / SECRET_ACCESS_KEY)
+ *   Cloudflare ダッシュボード → R2 → 右上「Manage R2 API Tokens」から発行する。
+ *   これは通常の CLOUDFLARE_API_TOKEN とは**別物**。
+ *   S3互換エンドポイント (https://<accountId>.r2.cloudflarestorage.com) に対して
+ *   AWS SDK の Signature V4 認証で使う。
+ *
+ * ### Cloudflare API トークン (CLOUDFLARE_API_TOKEN)
+ *   Cloudflare ダッシュボード → My Profile → API Tokens から発行する。
+ *   Pages の REST API (https://api.cloudflare.com/client/v4/accounts/…) に使う。
+ *   R2の S3互換API には使えない。
+ *
+ * ## 必要な権限
+ *   R2 S3互換キー : 対象バケットへの読み書き権限
+ *   API トークン  : Account:Cloudflare Pages:Edit
+ *
+ * ## 設定方法
+ *   export CLOUDFLARE_ACCOUNT_ID=<your-account-id>
+ *   export CLOUDFLARE_R2_ACCESS_KEY_ID=<r2-access-key-id>
+ *   export CLOUDFLARE_R2_SECRET_ACCESS_KEY=<r2-secret-access-key>
+ *   export CLOUDFLARE_API_TOKEN=<cf-api-token>
+ *
+ * config fileには認証情報を書かない。環境変数のみ。
+ */
+
+export interface R2Credentials {
+  accountId: string;
+  accessKeyId: string;
+  secretAccessKey: string;
+  /** R2 S3互換エンドポイント */
+  endpoint: string;
+}
+
+export interface PagesCredentials {
+  apiToken: string;
+  accountId: string;
+}
+
+export class AuthError extends Error {
+  constructor(message: string) {
+    super(`[AUTH] ${message}`);
+    this.name = 'AuthError';
+  }
+}
+
+function requireEnv(name: string, hint?: string): string {
+  const val = process.env[name];
+  if (!val) {
+    throw new AuthError(
+      `Environment variable ${name} is required but not set.\n` +
+        `  Set it with: export ${name}=<value>` +
+        (hint ? `\n  ${hint}` : '')
+    );
+  }
+  return val;
+}
+
+export function resolveR2Credentials(): R2Credentials {
+  const accountId = requireEnv('CLOUDFLARE_ACCOUNT_ID');
+  const accessKeyId = requireEnv(
+    'CLOUDFLARE_R2_ACCESS_KEY_ID',
+    'R2 S3互換キーは CF Dashboard → R2 → "Manage R2 API Tokens" から発行 (API Tokenとは別物)'
+  );
+  const secretAccessKey = requireEnv(
+    'CLOUDFLARE_R2_SECRET_ACCESS_KEY',
+    'R2 S3互換キーは CF Dashboard → R2 → "Manage R2 API Tokens" から発行 (API Tokenとは別物)'
+  );
+
+  return {
+    accountId,
+    accessKeyId,
+    secretAccessKey,
+    endpoint: `https://${accountId}.r2.cloudflarestorage.com`,
+  };
+}
+
+export function resolvePagesCredentials(): PagesCredentials {
+  const apiToken = requireEnv(
+    'CLOUDFLARE_API_TOKEN',
+    'CF Dashboard → My Profile → API Tokens から発行 (Pages:Edit 権限が必要)'
+  );
+  const accountId = requireEnv('CLOUDFLARE_ACCOUNT_ID');
+
+  return { apiToken, accountId };
+}

--- a/packages/deploy/src/push/cleanup.ts
+++ b/packages/deploy/src/push/cleanup.ts
@@ -1,0 +1,113 @@
+import type { DeployManifest } from '@static3d/types';
+import type { S3Client } from '@aws-sdk/client-s3';
+import { listAllR2Keys, deleteFromR2 } from './r2.js';
+
+export interface CleanupResult {
+  deleted: string[];
+  retained: string[];
+  /** プレフィックス外のキー（別プロジェクト等）— 触らない */
+  outOfScope: string[];
+}
+
+/**
+ * cdnBaseUrl から R2 キーのプレフィックスを導出する。
+ *
+ * 例:
+ *   https://cdn.example.com            → '' (バケット直下)
+ *   https://cdn.example.com/           → ''
+ *   https://cdn.example.com/v2         → 'v2/'
+ *   https://cdn.example.com/proj/v2/   → 'proj/v2/'
+ *
+ * ベースURLにパス部分がある場合（サブパスCDN構成）はそれをプレフィックスとして使う。
+ * バケット直下の場合は空文字列。
+ */
+export function extractKeyPrefix(cdnBaseUrl: string): string {
+  const url = new URL(cdnBaseUrl);
+  // pathname は "/" か "/some/path" の形式
+  const path = url.pathname.replace(/^\//, '').replace(/\/$/, '');
+  return path ? path + '/' : '';
+}
+
+/**
+ * R2バケット内の旧世代アセットを削除する。
+ *
+ * 安全設計:
+ *   - cdnBaseUrl のパスプレフィックスに一致するキーのみを操作対象にする。
+ *   - プレフィックス外のキー（別プロジェクト・別用途）は一切触らない。
+ *
+ * ロジック:
+ *   1. R2 の全オブジェクトキーを取得
+ *   2. prefix でフィルタ（スコープ外は outOfScope に分類して無視）
+ *   3. 現マニフェストのキー = 「現世代」(削除しない)
+ *   4. スコープ内かつ現世代でない = 「旧世代」→ 削除
+ *
+ * TODO(Phase 2): oldVersionRetention > 0 の多世代保持。
+ *   現状は retention > 0 のとき削除をスキップし警告のみ。
+ *   実装方針: R2 オブジェクトメタデータに deployedAt を記録し、
+ *             最新 N 世代のキーセットを保持して残りを削除する。
+ */
+export async function cleanupOldAssets(
+  s3: S3Client,
+  bucket: string,
+  currentManifest: DeployManifest,
+  cdnBaseUrl: string,
+  retention: number = 0
+): Promise<CleanupResult> {
+  if (retention > 0) {
+    console.log(
+      `[CLEANUP] oldVersionRetention=${retention} — deletion skipped` +
+        ` (multi-version retention not yet implemented)`
+    );
+    return { deleted: [], retained: [], outOfScope: [] };
+  }
+
+  // cdnBaseUrl のパス部分をプレフィックスとして使う
+  const prefix = extractKeyPrefix(cdnBaseUrl);
+
+  // 現マニフェストのアセット URL → R2 キー を逆引き
+  // URL: https://cdn.example.com[/prefix]/hashedKey
+  // → R2 key: [prefix/]hashedKey
+  const currentKeys = new Set(
+    Object.values(currentManifest.assets).map((a) => {
+      const url = new URL(a.url);
+      // pathname: /[prefix/]hashedKey → prefix/hashedKey (先頭スラッシュ除去)
+      return url.pathname.replace(/^\//, '');
+    })
+  );
+
+  const allKeys = await listAllR2Keys(s3, bucket);
+
+  const toDelete: string[] = [];
+  const retained: string[] = [];
+  const outOfScope: string[] = [];
+
+  for (const key of allKeys) {
+    // プレフィックス外のキーは別プロジェクトの可能性があるので絶対に触らない
+    if (prefix && !key.startsWith(prefix)) {
+      outOfScope.push(key);
+      continue;
+    }
+
+    if (currentKeys.has(key)) {
+      retained.push(key);
+    } else {
+      toDelete.push(key);
+    }
+  }
+
+  if (outOfScope.length > 0) {
+    console.log(
+      `[CLEANUP] ${outOfScope.length} key(s) outside prefix "${prefix}" — skipped (not owned by this project)`
+    );
+  }
+
+  if (toDelete.length === 0) {
+    console.log('[CLEANUP] No old assets to delete');
+    return { deleted: [], retained, outOfScope };
+  }
+
+  console.log(`[CLEANUP] Deleting ${toDelete.length} old asset(s) with prefix "${prefix}"...`);
+  await deleteFromR2(s3, bucket, toDelete);
+
+  return { deleted: toDelete, retained, outOfScope };
+}

--- a/packages/deploy/src/push/diff.ts
+++ b/packages/deploy/src/push/diff.ts
@@ -1,0 +1,54 @@
+import { S3Client, ListObjectsV2Command } from '@aws-sdk/client-s3';
+import type { R2Credentials } from '../config/auth.js';
+
+export interface DiffResult {
+  /** R2に存在しない → アップロード必要 */
+  toUpload: string[];
+  /** R2に既に存在する → スキップ */
+  alreadyExists: string[];
+}
+
+/**
+ * dist/cdn/ 以下のファイルキー一覧とR2の現状を比較して差分を返す。
+ *
+ * コンテンツハッシュがファイル名に含まれているため
+ * 「同名ファイル = 同一内容」が保証される。
+ * → R2に既に存在するキーは無条件スキップできる。
+ */
+export async function computeDiff(
+  s3: S3Client,
+  bucket: string,
+  localKeys: string[]
+): Promise<DiffResult> {
+  const remoteKeys = new Set<string>();
+
+  // R2のオブジェクト一覧を全ページ取得
+  let continuationToken: string | undefined;
+  do {
+    const res = await s3.send(
+      new ListObjectsV2Command({
+        Bucket: bucket,
+        ContinuationToken: continuationToken,
+      })
+    );
+
+    for (const obj of res.Contents ?? []) {
+      if (obj.Key) remoteKeys.add(obj.Key);
+    }
+
+    continuationToken = res.NextContinuationToken;
+  } while (continuationToken);
+
+  const toUpload: string[] = [];
+  const alreadyExists: string[] = [];
+
+  for (const key of localKeys) {
+    if (remoteKeys.has(key)) {
+      alreadyExists.push(key);
+    } else {
+      toUpload.push(key);
+    }
+  }
+
+  return { toUpload, alreadyExists };
+}

--- a/packages/deploy/src/push/index.ts
+++ b/packages/deploy/src/push/index.ts
@@ -1,0 +1,119 @@
+import { resolve, join } from 'node:path';
+import { existsSync, readFileSync } from 'node:fs';
+import { glob } from 'glob';
+import type { DeployConfig } from '@static3d/types';
+import type { DeployManifest } from '@static3d/types';
+import { resolveR2Credentials, resolvePagesCredentials } from '../config/auth.js';
+import { createR2Client, verifyR2Access, uploadToR2 } from './r2.js';
+import { deployToPages } from './pages.js';
+import { cleanupOldAssets } from './cleanup.js';
+
+export interface PushOptions {
+  /** Cloudflare Pages プロジェクト名 (デフォルト: config.project) */
+  projectName?: string;
+  /** 旧世代クリーンアップをスキップ */
+  skipCleanup?: boolean;
+  /** Pages デプロイをスキップ (CDNのみ更新) */
+  skipPages?: boolean;
+}
+
+export async function push(
+  config: DeployConfig,
+  projectName: string,
+  options: PushOptions = {}
+): Promise<void> {
+  const pagesOutputDir = resolve(config.pages.outputDir ?? 'dist/pages');
+  const cdnOutputDir = resolve('dist/cdn');
+  const manifestPath = join(pagesOutputDir, 'manifest.json');
+
+  // ---- 前提条件チェック ----
+  if (!existsSync(pagesOutputDir)) {
+    throw new Error(
+      `[PUSH] ${pagesOutputDir} not found. Run "static3d-deploy build" first.`
+    );
+  }
+  if (!existsSync(manifestPath)) {
+    throw new Error(
+      `[PUSH] manifest.json not found at ${manifestPath}. Run "static3d-deploy build" first.`
+    );
+  }
+  if (!existsSync(cdnOutputDir)) {
+    throw new Error(
+      `[PUSH] ${cdnOutputDir} not found. Run "static3d-deploy build" first.`
+    );
+  }
+
+  const manifest: DeployManifest = JSON.parse(
+    readFileSync(manifestPath, 'utf-8')
+  );
+
+  console.log(`[PUSH] Starting deployment (version: ${manifest.version})`);
+
+  // ---- 認証情報解決 ----
+  const r2Creds = resolveR2Credentials();
+  const pagesCreds = !options.skipPages ? resolvePagesCredentials() : null;
+
+  // ---- R2 疎通確認 ----
+  const s3 = createR2Client(r2Creds);
+  console.log(`[PUSH] Verifying R2 access to bucket "${config.cdn.bucket}"...`);
+  await verifyR2Access(s3, config.cdn.bucket);
+  console.log('[PUSH] R2 access OK');
+
+  // ---- dist/cdn/ 以下のキー一覧収集 ----
+  const cdnFiles = await glob('**/*', {
+    cwd: cdnOutputDir,
+    nodir: true,
+  });
+  const hashedKeys = cdnFiles.map((f) => f.replace(/\\/g, '/'));
+
+  // ---- R2 差分アップロード ----
+  console.log(`[PUSH] Uploading ${hashedKeys.length} CDN asset(s) to R2...`);
+  const r2Result = await uploadToR2(
+    s3,
+    config.cdn.bucket,
+    cdnOutputDir,
+    hashedKeys,
+    (done, total, key) => {
+      process.stdout.write(`[R2] (${done + 1}/${total}) ${key}\r`);
+    }
+  );
+  console.log(
+    `[PUSH] R2 upload complete: ${r2Result.uploaded} uploaded, ${r2Result.skipped} skipped, ` +
+      `${(r2Result.totalBytes / 1024).toFixed(1)}KB total`
+  );
+
+  // ---- Pages デプロイ ----
+  // 原子性保証: R2アップロード完了後にPagesをデプロイ
+  // Pagesがmanifestを配信し始めた時点で全CDNアセットが存在している
+  if (!options.skipPages && pagesCreds) {
+    const pagesResult = await deployToPages(
+      pagesCreds,
+      projectName,
+      pagesOutputDir
+    );
+    console.log(`[PUSH] Pages deployed: ${pagesResult.url}`);
+  } else {
+    console.log('[PUSH] Pages deploy skipped');
+  }
+
+  // ---- 旧世代クリーンアップ ----
+  if (!options.skipCleanup) {
+    const retention = config.oldVersionRetention ?? 0;
+    const cleanupResult = await cleanupOldAssets(
+      s3,
+      config.cdn.bucket,
+      manifest,
+      config.cdn.baseUrl,
+      retention
+    );
+    if (cleanupResult.deleted.length > 0) {
+      console.log(
+        `[PUSH] Cleanup: ${cleanupResult.deleted.length} old asset(s) deleted`
+      );
+    }
+  } else {
+    console.log('[PUSH] Cleanup skipped');
+  }
+
+  console.log(`[PUSH] Done ✓  (version: ${manifest.version})`);
+}

--- a/packages/deploy/src/push/pages.ts
+++ b/packages/deploy/src/push/pages.ts
@@ -1,0 +1,160 @@
+import { readFileSync, readdirSync, statSync } from 'node:fs';
+import { join, resolve, relative } from 'node:path';
+import { glob } from 'glob';
+import type { PagesCredentials } from '../config/auth.js';
+
+const CF_API = 'https://api.cloudflare.com/client/v4';
+
+export interface PagesDeployResult {
+  deploymentId: string;
+  url: string;
+  environment: string;
+}
+
+export class PagesError extends Error {
+  constructor(
+    message: string,
+    public readonly statusCode?: number
+  ) {
+    super(`[PAGES] ${message}`);
+    this.name = 'PagesError';
+  }
+}
+
+/**
+ * Pages プロジェクトが存在するか確認し、なければ作成する
+ */
+async function ensurePagesProject(
+  creds: PagesCredentials,
+  projectName: string
+): Promise<void> {
+  const res = await fetch(
+    `${CF_API}/accounts/${creds.accountId}/pages/projects/${projectName}`,
+    {
+      headers: {
+        Authorization: `Bearer ${creds.apiToken}`,
+        'Content-Type': 'application/json',
+      },
+    }
+  );
+
+  if (res.status === 404) {
+    // プロジェクト作成
+    const createRes = await fetch(
+      `${CF_API}/accounts/${creds.accountId}/pages/projects`,
+      {
+        method: 'POST',
+        headers: {
+          Authorization: `Bearer ${creds.apiToken}`,
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({
+          name: projectName,
+          production_branch: 'main',
+        }),
+      }
+    );
+
+    if (!createRes.ok) {
+      const body = await createRes.text();
+      throw new PagesError(
+        `Failed to create project "${projectName}": ${createRes.status} ${body}`,
+        createRes.status
+      );
+    }
+
+    console.log(`[PAGES] Created project: ${projectName}`);
+    return;
+  }
+
+  if (!res.ok) {
+    const body = await res.text();
+    throw new PagesError(
+      `Failed to check project "${projectName}": ${res.status} ${body}`,
+      res.status
+    );
+  }
+}
+
+/**
+ * dist/pages/ を Cloudflare Pages に Direct Upload でデプロイする。
+ *
+ * フロー:
+ *   1. deployment を作成 (multipart/form-data で全ファイルを送信)
+ *   2. デプロイIDと公開URLを返す
+ */
+export async function deployToPages(
+  creds: PagesCredentials,
+  projectName: string,
+  pagesOutputDir: string
+): Promise<PagesDeployResult> {
+  const pagesDir = resolve(pagesOutputDir);
+
+  await ensurePagesProject(creds, projectName);
+
+  console.log(`[PAGES] Deploying ${pagesDir} to project "${projectName}"...`);
+
+  // dist/pages 以下の全ファイルを収集
+  const files = await glob('**/*', {
+    cwd: pagesDir,
+    nodir: true,
+    absolute: false,
+  });
+
+  if (files.length === 0) {
+    throw new PagesError(`No files found in ${pagesDir}`);
+  }
+
+  // multipart/form-data でまとめて送信
+  const formData = new FormData();
+
+  for (const file of files) {
+    const absPath = join(pagesDir, file);
+    const content = readFileSync(absPath);
+    const blob = new Blob([content]);
+    // Cloudflare Pages API は / 始まりのパスを要求する
+    const pagePath = '/' + file.replace(/\\/g, '/');
+    formData.append('files', blob, pagePath);
+  }
+
+  const res = await fetch(
+    `${CF_API}/accounts/${creds.accountId}/pages/projects/${projectName}/deployments`,
+    {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${creds.apiToken}`,
+        // Content-Type は FormData が自動設定するので指定しない
+      },
+      body: formData,
+    }
+  );
+
+  if (!res.ok) {
+    const body = await res.text();
+    throw new PagesError(
+      `Deployment failed: ${res.status} ${body}`,
+      res.status
+    );
+  }
+
+  const data = (await res.json()) as {
+    result: {
+      id: string;
+      url: string;
+      environment: string;
+      aliases?: string[];
+    };
+  };
+
+  const result = data.result;
+  const url = result.aliases?.[0] ?? result.url;
+
+  console.log(`[PAGES] ✓ Deployed: ${url}`);
+  console.log(`[PAGES]   Deployment ID: ${result.id}`);
+
+  return {
+    deploymentId: result.id,
+    url,
+    environment: result.environment,
+  };
+}

--- a/packages/deploy/src/push/r2.ts
+++ b/packages/deploy/src/push/r2.ts
@@ -1,0 +1,177 @@
+import {
+  S3Client,
+  PutObjectCommand,
+  ListObjectsV2Command,
+  DeleteObjectsCommand,
+} from '@aws-sdk/client-s3';
+import { Upload } from '@aws-sdk/lib-storage';
+import { createReadStream, statSync } from 'node:fs';
+import { join, resolve } from 'node:path';
+import { lookup } from 'mime-types';
+import type { R2Credentials } from '../config/auth.js';
+import { computeDiff } from './diff.js';
+
+const MULTIPART_THRESHOLD = 5 * 1024 * 1024; // 5MB以上はマルチパート
+
+export interface R2UploadResult {
+  uploaded: number;
+  skipped: number;
+  totalBytes: number;
+}
+
+export function createR2Client(creds: R2Credentials): S3Client {
+  return new S3Client({
+    region: 'auto',
+    endpoint: creds.endpoint,
+    credentials: {
+      accessKeyId: creds.accessKeyId,
+      secretAccessKey: creds.secretAccessKey,
+    },
+    // R2はpath-styleを使う
+    forcePathStyle: false,
+  });
+}
+
+/**
+ * R2との疎通確認
+ * バケットが存在してアクセス可能かを検証する。
+ */
+export async function verifyR2Access(
+  s3: S3Client,
+  bucket: string
+): Promise<void> {
+  try {
+    await s3.send(
+      new ListObjectsV2Command({ Bucket: bucket, MaxKeys: 1 })
+    );
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    throw new Error(
+      `[R2] Cannot access bucket "${bucket}": ${msg}\n` +
+        `  Check CLOUDFLARE_ACCOUNT_ID, CLOUDFLARE_R2_ACCESS_KEY_ID, CLOUDFLARE_R2_SECRET_ACCESS_KEY`
+    );
+  }
+}
+
+/**
+ * dist/cdn/ 以下のアセットをR2に差分アップロードする。
+ * コンテンツハッシュ名なので既存キーはスキップ。
+ */
+export async function uploadToR2(
+  s3: S3Client,
+  bucket: string,
+  cdnOutputDir: string,
+  hashedKeys: string[],
+  onProgress?: (uploaded: number, total: number, key: string) => void
+): Promise<R2UploadResult> {
+  const cdnDir = resolve(cdnOutputDir);
+
+  // 差分計算
+  const diff = await computeDiff(s3, bucket, hashedKeys);
+
+  console.log(
+    `[R2] ${diff.toUpload.length} to upload, ${diff.alreadyExists.length} already exist`
+  );
+
+  let uploaded = 0;
+  let totalBytes = 0;
+
+  for (const key of diff.toUpload) {
+    const filePath = join(cdnDir, key);
+    const size = statSync(filePath).size;
+    const contentType = lookup(key) || 'application/octet-stream';
+
+    onProgress?.(uploaded, diff.toUpload.length, key);
+
+    if (size >= MULTIPART_THRESHOLD) {
+      // 5MB以上はマルチパートアップロード
+      const upload = new Upload({
+        client: s3,
+        params: {
+          Bucket: bucket,
+          Key: key,
+          Body: createReadStream(filePath),
+          ContentType: contentType,
+          // コンテンツハッシュ名なので immutable キャッシュ
+          CacheControl: 'public, max-age=31536000, immutable',
+        },
+      });
+      await upload.done();
+    } else {
+      const { readFileSync } = await import('node:fs');
+      await s3.send(
+        new PutObjectCommand({
+          Bucket: bucket,
+          Key: key,
+          Body: readFileSync(filePath),
+          ContentType: contentType,
+          CacheControl: 'public, max-age=31536000, immutable',
+        })
+      );
+    }
+
+    uploaded++;
+    totalBytes += size;
+    console.log(`[R2] ✓ ${key} (${(size / 1024).toFixed(1)}KB)`);
+  }
+
+  // スキップしたファイルをまとめて表示
+  if (diff.alreadyExists.length > 0) {
+    console.log(`[R2] Skipped ${diff.alreadyExists.length} unchanged files`);
+  }
+
+  return { uploaded, skipped: diff.alreadyExists.length, totalBytes };
+}
+
+/**
+ * 指定したキー一覧をR2から削除する（旧世代クリーンアップ用）
+ */
+export async function deleteFromR2(
+  s3: S3Client,
+  bucket: string,
+  keys: string[]
+): Promise<void> {
+  if (keys.length === 0) return;
+
+  // DeleteObjects は最大1000件
+  const CHUNK = 1000;
+  for (let i = 0; i < keys.length; i += CHUNK) {
+    const chunk = keys.slice(i, i + CHUNK);
+    await s3.send(
+      new DeleteObjectsCommand({
+        Bucket: bucket,
+        Delete: {
+          Objects: chunk.map((Key) => ({ Key })),
+          Quiet: true,
+        },
+      })
+    );
+    console.log(`[R2] Deleted ${chunk.length} old assets`);
+  }
+}
+
+/**
+ * R2バケット内の全オブジェクトキー一覧を返す
+ */
+export async function listAllR2Keys(
+  s3: S3Client,
+  bucket: string
+): Promise<string[]> {
+  const keys: string[] = [];
+  let continuationToken: string | undefined;
+
+  do {
+    const res = await s3.send(
+      new ListObjectsV2Command({
+        Bucket: bucket,
+        ContinuationToken: continuationToken,
+      })
+    );
+    for (const obj of res.Contents ?? []) {
+      if (obj.Key) keys.push(obj.Key);
+    }
+    continuationToken = res.NextContinuationToken;
+  } while (continuationToken);
+
+  return keys;
+}

--- a/packages/deploy/src/tests/auth.test.ts
+++ b/packages/deploy/src/tests/auth.test.ts
@@ -1,0 +1,77 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { resolveR2Credentials, resolvePagesCredentials, AuthError } from '../config/auth.js';
+
+describe('auth', () => {
+  const originalEnv = { ...process.env };
+
+  beforeEach(() => {
+    // テスト前に関連env varをクリア
+    delete process.env.CLOUDFLARE_ACCOUNT_ID;
+    delete process.env.CLOUDFLARE_R2_ACCESS_KEY_ID;
+    delete process.env.CLOUDFLARE_R2_SECRET_ACCESS_KEY;
+    delete process.env.CLOUDFLARE_API_TOKEN;
+  });
+
+  afterEach(() => {
+    // テスト後に元に戻す
+    process.env = { ...originalEnv };
+  });
+
+  describe('resolveR2Credentials', () => {
+    it('resolves credentials from env vars', () => {
+      process.env.CLOUDFLARE_ACCOUNT_ID = 'abc123';
+      process.env.CLOUDFLARE_R2_ACCESS_KEY_ID = 'key-id';
+      process.env.CLOUDFLARE_R2_SECRET_ACCESS_KEY = 'secret-key';
+
+      const creds = resolveR2Credentials();
+
+      expect(creds.accountId).toBe('abc123');
+      expect(creds.accessKeyId).toBe('key-id');
+      expect(creds.secretAccessKey).toBe('secret-key');
+      expect(creds.endpoint).toBe('https://abc123.r2.cloudflarestorage.com');
+    });
+
+    it('throws AuthError when CLOUDFLARE_ACCOUNT_ID is missing', () => {
+      process.env.CLOUDFLARE_R2_ACCESS_KEY_ID = 'key-id';
+      process.env.CLOUDFLARE_R2_SECRET_ACCESS_KEY = 'secret-key';
+
+      expect(() => resolveR2Credentials()).toThrow(AuthError);
+      expect(() => resolveR2Credentials()).toThrow('CLOUDFLARE_ACCOUNT_ID');
+    });
+
+    it('throws AuthError when R2 access key is missing', () => {
+      process.env.CLOUDFLARE_ACCOUNT_ID = 'abc123';
+      process.env.CLOUDFLARE_R2_SECRET_ACCESS_KEY = 'secret-key';
+
+      expect(() => resolveR2Credentials()).toThrow(AuthError);
+      expect(() => resolveR2Credentials()).toThrow('CLOUDFLARE_R2_ACCESS_KEY_ID');
+    });
+
+    it('constructs correct R2 endpoint URL', () => {
+      process.env.CLOUDFLARE_ACCOUNT_ID = 'myaccount';
+      process.env.CLOUDFLARE_R2_ACCESS_KEY_ID = 'key';
+      process.env.CLOUDFLARE_R2_SECRET_ACCESS_KEY = 'secret';
+
+      const { endpoint } = resolveR2Credentials();
+      expect(endpoint).toBe('https://myaccount.r2.cloudflarestorage.com');
+    });
+  });
+
+  describe('resolvePagesCredentials', () => {
+    it('resolves credentials from env vars', () => {
+      process.env.CLOUDFLARE_API_TOKEN = 'token-xyz';
+      process.env.CLOUDFLARE_ACCOUNT_ID = 'acc-123';
+
+      const creds = resolvePagesCredentials();
+      expect(creds.apiToken).toBe('token-xyz');
+      expect(creds.accountId).toBe('acc-123');
+    });
+
+    it('throws AuthError when API token is missing', () => {
+      process.env.CLOUDFLARE_ACCOUNT_ID = 'acc-123';
+
+      expect(() => resolvePagesCredentials()).toThrow(AuthError);
+      expect(() => resolvePagesCredentials()).toThrow('CLOUDFLARE_API_TOKEN');
+    });
+  });
+});

--- a/packages/deploy/src/tests/cleanup.test.ts
+++ b/packages/deploy/src/tests/cleanup.test.ts
@@ -1,0 +1,170 @@
+import { describe, it, expect, vi } from 'vitest';
+import { cleanupOldAssets, extractKeyPrefix } from '../push/cleanup.js';
+import type { DeployManifest } from '@static3d/types';
+import type { S3Client } from '@aws-sdk/client-s3';
+
+function makeManifest(cdnBase: string, hashedKeys: string[]): DeployManifest {
+  const assets: DeployManifest['assets'] = {};
+  for (const key of hashedKeys) {
+    const originalKey = key.replace(/\.[0-9a-f]{8,16}(\.[^.]+)$/, '$1');
+    assets[originalKey] = {
+      url: `${cdnBase}/${key}`,
+      size: 100,
+      hash: 'sha256:' + 'a'.repeat(64),
+      contentType: 'application/octet-stream',
+    };
+  }
+  return {
+    schemaVersion: 1,
+    version: 'abc1234',
+    buildTime: new Date().toISOString(),
+    assets,
+  };
+}
+
+function makeS3Mock(allKeys: string[], deletedKeys: string[] = []): S3Client {
+  return {
+    send: vi.fn().mockImplementation((cmd: unknown) => {
+      const cmdName = (cmd as { constructor: { name: string } }).constructor.name;
+      if (cmdName === 'ListObjectsV2Command') {
+        return Promise.resolve({
+          Contents: allKeys.map((Key) => ({ Key })),
+          NextContinuationToken: undefined,
+        });
+      }
+      if (cmdName === 'DeleteObjectsCommand') {
+        const input = (cmd as { input: { Delete: { Objects: { Key: string }[] } } }).input;
+        deletedKeys.push(...input.Delete.Objects.map((o) => o.Key));
+        return Promise.resolve({});
+      }
+      return Promise.resolve({});
+    }),
+  } as unknown as S3Client;
+}
+
+const CDN_BASE = 'https://cdn.example.com';
+
+describe('extractKeyPrefix', () => {
+  it('returns empty string for bare origin URL', () => {
+    expect(extractKeyPrefix('https://cdn.example.com')).toBe('');
+    expect(extractKeyPrefix('https://cdn.example.com/')).toBe('');
+  });
+
+  it('returns prefix with trailing slash for single-segment path', () => {
+    expect(extractKeyPrefix('https://cdn.example.com/v2')).toBe('v2/');
+    expect(extractKeyPrefix('https://cdn.example.com/v2/')).toBe('v2/');
+  });
+
+  it('returns full prefix for multi-segment path', () => {
+    expect(extractKeyPrefix('https://cdn.example.com/proj/v2')).toBe('proj/v2/');
+    expect(extractKeyPrefix('https://cdn.example.com/a/b/c/')).toBe('a/b/c/');
+  });
+});
+
+describe('cleanup', () => {
+  it('deletes old keys within prefix, retains current keys', async () => {
+    const currentKeys = ['models/scene.abc12345.gltf', 'textures/albedo.deadbeef.png'];
+    const oldKeys = ['models/scene.00000000.gltf', 'textures/albedo.11111111.png'];
+    const allR2Keys = [...currentKeys, ...oldKeys];
+
+    const manifest = makeManifest(CDN_BASE, currentKeys);
+    const s3 = makeS3Mock(allR2Keys);
+
+    const result = await cleanupOldAssets(s3, 'test-bucket', manifest, CDN_BASE, 0);
+
+    expect(result.deleted).toHaveLength(2);
+    expect(result.deleted).toContain('models/scene.00000000.gltf');
+    expect(result.deleted).toContain('textures/albedo.11111111.png');
+    expect(result.retained).toHaveLength(2);
+    expect(result.outOfScope).toHaveLength(0);
+  });
+
+  it('retains all keys when all are current', async () => {
+    const currentKeys = ['models/scene.abc12345.gltf'];
+    const manifest = makeManifest(CDN_BASE, currentKeys);
+    const s3 = makeS3Mock(currentKeys);
+
+    const result = await cleanupOldAssets(s3, 'test-bucket', manifest, CDN_BASE, 0);
+
+    expect(result.deleted).toHaveLength(0);
+    expect(result.retained).toHaveLength(1);
+  });
+
+  it('skips deletion when retention > 0', async () => {
+    const currentKeys = ['models/scene.abc12345.gltf'];
+    const manifest = makeManifest(CDN_BASE, currentKeys);
+    const s3 = makeS3Mock(['models/scene.abc12345.gltf', 'models/scene.old00000.gltf']);
+
+    const result = await cleanupOldAssets(s3, 'test-bucket', manifest, CDN_BASE, 3);
+
+    expect(result.deleted).toHaveLength(0);
+    expect(result.outOfScope).toHaveLength(0);
+  });
+
+  it('never touches keys outside of cdnBaseUrl prefix', async () => {
+    // バケットを別プロジェクトと共有している状況
+    // CDN: https://cdn.example.com/project-a
+    // R2キー形式: project-a/<hashedKey>
+    const cdnBase = 'https://cdn.example.com/project-a';
+
+    // makeManifest は cdnBase + '/' + hashedKey で URL を作る。
+    // extractKeyPrefix('https://cdn.example.com/project-a') → 'project-a/'
+    // cleanupOldAssets の URL逆引きは pathname の先頭 '/' を除去するだけなので
+    // URL: https://cdn.example.com/project-a/models/scene.abc12345.gltf
+    // → pathname: /project-a/models/scene.abc12345.gltf
+    // → key: project-a/models/scene.abc12345.gltf  ← R2上の実際のキー
+    const currentHashedKey = 'project-a/models/scene.abc12345.gltf';
+    const otherProjectKeys = [
+      'project-b/models/other.deadbeef.glb',  // 別プロジェクト → 絶対触らない
+      'project-b/textures/tex.cafebabe.png',
+    ];
+    const oldKey = 'project-a/models/scene.00000000.gltf'; // 旧世代 → 削除対象
+
+    const allR2Keys = [currentHashedKey, oldKey, ...otherProjectKeys];
+
+    // makeManifest: assets[originalKey].url = cdnBase + '/' + hashedKey
+    // = 'https://cdn.example.com/project-a/project-a/models/scene.abc12345.gltf' では困る。
+    // URL逆引きロジックに合わせて、manifest を直接組み立てる。
+    const manifest: DeployManifest = {
+      schemaVersion: 1,
+      version: 'test',
+      buildTime: new Date().toISOString(),
+      assets: {
+        'models/scene.gltf': {
+          // URL の pathname = /project-a/models/scene.abc12345.gltf → key = project-a/models/scene.abc12345.gltf
+          url: `https://cdn.example.com/${currentHashedKey}`,
+          size: 100,
+          hash: 'sha256:' + 'a'.repeat(64),
+          contentType: 'model/gltf+json',
+        },
+      },
+    };
+
+    const s3 = makeS3Mock(allR2Keys);
+
+    const result = await cleanupOldAssets(s3, 'test-bucket', manifest, cdnBase, 0);
+
+    // 旧世代のみ削除
+    expect(result.deleted).toHaveLength(1);
+    expect(result.deleted).toContain('project-a/models/scene.00000000.gltf');
+
+    // 別プロジェクトのキーは outOfScope に分類され削除されない
+    expect(result.outOfScope).toHaveLength(2);
+    expect(result.outOfScope).toContain('project-b/models/other.deadbeef.glb');
+    expect(result.outOfScope).toContain('project-b/textures/tex.cafebabe.png');
+  });
+
+  it('handles bare-origin CDN URL (no prefix) without touching unrelated keys', async () => {
+    // プレフィックスなしの場合、バケット内の全キーがスコープ内になる
+    // (バケット1プロジェクト専用の構成)
+    const currentKeys = ['scene.abc12345.gltf'];
+    const oldKeys = ['scene.00000000.gltf'];
+    const manifest = makeManifest(CDN_BASE, currentKeys);
+    const s3 = makeS3Mock([...currentKeys, ...oldKeys]);
+
+    const result = await cleanupOldAssets(s3, 'test-bucket', manifest, CDN_BASE, 0);
+
+    expect(result.deleted).toContain('scene.00000000.gltf');
+    expect(result.outOfScope).toHaveLength(0);
+  });
+});

--- a/packages/deploy/src/tests/diff.test.ts
+++ b/packages/deploy/src/tests/diff.test.ts
@@ -1,0 +1,56 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { computeDiff } from '../push/diff.js';
+import type { S3Client } from '@aws-sdk/client-s3';
+
+// S3ClientのListObjectsV2をモックする
+function makeS3Mock(existingKeys: string[]): S3Client {
+  return {
+    send: vi.fn().mockImplementation((cmd: { input: { ContinuationToken?: string } }) => {
+      return Promise.resolve({
+        Contents: existingKeys.map((Key) => ({ Key })),
+        NextContinuationToken: undefined,
+      });
+    }),
+  } as unknown as S3Client;
+}
+
+describe('diff', () => {
+  it('identifies files to upload and files already existing', async () => {
+    const s3 = makeS3Mock(['models/scene.abc12345.gltf', 'textures/albedo.deadbeef.png']);
+
+    const localKeys = [
+      'models/scene.abc12345.gltf',       // 既存 → スキップ
+      'textures/albedo.deadbeef.png',     // 既存 → スキップ
+      'textures/normal.cafebabe.png',     // 新規 → アップロード
+      'models/env.00001111.hdr',          // 新規 → アップロード
+    ];
+
+    const result = await computeDiff(s3, 'test-bucket', localKeys);
+
+    expect(result.toUpload).toHaveLength(2);
+    expect(result.toUpload).toContain('textures/normal.cafebabe.png');
+    expect(result.toUpload).toContain('models/env.00001111.hdr');
+
+    expect(result.alreadyExists).toHaveLength(2);
+    expect(result.alreadyExists).toContain('models/scene.abc12345.gltf');
+    expect(result.alreadyExists).toContain('textures/albedo.deadbeef.png');
+  });
+
+  it('treats empty R2 bucket as all-new upload', async () => {
+    const s3 = makeS3Mock([]);
+    const localKeys = ['a.abc12345.glb', 'b.deadbeef.png'];
+
+    const result = await computeDiff(s3, 'test-bucket', localKeys);
+
+    expect(result.toUpload).toHaveLength(2);
+    expect(result.alreadyExists).toHaveLength(0);
+  });
+
+  it('treats empty local as nothing to upload', async () => {
+    const s3 = makeS3Mock(['old.abc12345.glb']);
+    const result = await computeDiff(s3, 'test-bucket', []);
+
+    expect(result.toUpload).toHaveLength(0);
+    expect(result.alreadyExists).toHaveLength(0);
+  });
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -10,6 +10,12 @@ importers:
 
   packages/deploy:
     dependencies:
+      '@aws-sdk/client-s3':
+        specifier: ^3.993.0
+        version: 3.993.0
+      '@aws-sdk/lib-storage':
+        specifier: ^3.993.0
+        version: 3.993.0(@aws-sdk/client-s3@3.993.0)
       '@static3d/types':
         specifier: workspace:*
         version: link:../types
@@ -43,6 +49,175 @@ importers:
         version: 5.9.3
 
 packages:
+
+  '@aws-crypto/crc32@5.2.0':
+    resolution: {integrity: sha512-nLbCWqQNgUiwwtFsen1AdzAtvuLRsQS8rYgMuxCrdKf9kOssamGLuPwyTY9wyYblNr9+1XM8v6zoDTPPSIeANg==}
+    engines: {node: '>=16.0.0'}
+
+  '@aws-crypto/crc32c@5.2.0':
+    resolution: {integrity: sha512-+iWb8qaHLYKrNvGRbiYRHSdKRWhto5XlZUEBwDjYNf+ly5SVYG6zEoYIdxvf5R3zyeP16w4PLBn3rH1xc74Rag==}
+
+  '@aws-crypto/sha1-browser@5.2.0':
+    resolution: {integrity: sha512-OH6lveCFfcDjX4dbAvCFSYUjJZjDr/3XJ3xHtjn3Oj5b9RjojQo8npoLeA/bNwkOkrSQ0wgrHzXk4tDRxGKJeg==}
+
+  '@aws-crypto/sha256-browser@5.2.0':
+    resolution: {integrity: sha512-AXfN/lGotSQwu6HNcEsIASo7kWXZ5HYWvfOmSNKDsEqC4OashTp8alTmaz+F7TC2L083SFv5RdB+qU3Vs1kZqw==}
+
+  '@aws-crypto/sha256-js@5.2.0':
+    resolution: {integrity: sha512-FFQQyu7edu4ufvIZ+OadFpHHOt+eSTBaYaki44c+akjg7qZg9oOQeLlk77F6tSYqjDAFClrHJk9tMf0HdVyOvA==}
+    engines: {node: '>=16.0.0'}
+
+  '@aws-crypto/supports-web-crypto@5.2.0':
+    resolution: {integrity: sha512-iAvUotm021kM33eCdNfwIN//F77/IADDSs58i+MDaOqFrVjZo9bAal0NK7HurRuWLLpF1iLX7gbWrjHjeo+YFg==}
+
+  '@aws-crypto/util@5.2.0':
+    resolution: {integrity: sha512-4RkU9EsI6ZpBve5fseQlGNUWKMa1RLPQ1dnjnQoe07ldfIzcsGb5hC5W0Dm7u423KWzawlrpbjXBrXCEv9zazQ==}
+
+  '@aws-sdk/client-s3@3.993.0':
+    resolution: {integrity: sha512-0slCxdbo9O3rfzqD7/PsBOrZ6vcwFzPAvGeUu5NZApI5WyjEfMLLi2T9QW8R9N9TQeUfiUQiHkg/NV0LPS61/g==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/client-sso@3.993.0':
+    resolution: {integrity: sha512-VLUN+wIeNX24fg12SCbzTUBnBENlL014yMKZvRhPkcn4wHR6LKgNrjsG3fZ03Xs0XoKaGtNFi1VVrq666sGBoQ==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/core@3.973.11':
+    resolution: {integrity: sha512-wdQ8vrvHkKIV7yNUKXyjPWKCdYEUrZTHJ8Ojd5uJxXp9vqPCkUR1dpi1NtOLcrDgueJH7MUH5lQZxshjFPSbDA==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/crc64-nvme@3.972.0':
+    resolution: {integrity: sha512-ThlLhTqX68jvoIVv+pryOdb5coP1cX1/MaTbB9xkGDCbWbsqQcLqzPxuSoW1DCnAAIacmXCWpzUNOB9pv+xXQw==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-env@3.972.9':
+    resolution: {integrity: sha512-ZptrOwQynfupubvcngLkbdIq/aXvl/czdpEG8XJ8mN8Nb19BR0jaK0bR+tfuMU36Ez9q4xv7GGkHFqEEP2hUUQ==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-http@3.972.11':
+    resolution: {integrity: sha512-hECWoOoH386bGr89NQc9vA/abkGf5TJrMREt+lhNcnSNmoBS04fK7vc3LrJBSQAUGGVj0Tz3f4dHB3w5veovig==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-ini@3.972.9':
+    resolution: {integrity: sha512-zr1csEu9n4eDiHMTYJabX1mDGuGLgjgUnNckIivvk43DocJC9/f6DefFrnUPZXE+GHtbW50YuXb+JIxKykU74A==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-login@3.972.9':
+    resolution: {integrity: sha512-m4RIpVgZChv0vWS/HKChg1xLgZPpx8Z+ly9Fv7FwA8SOfuC6I3htcSaBz2Ch4bneRIiBUhwP4ziUo0UZgtJStQ==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-node@3.972.10':
+    resolution: {integrity: sha512-70nCESlvnzjo4LjJ8By8MYIiBogkYPSXl3WmMZfH9RZcB/Nt9qVWbFpYj6Fk1vLa4Vk8qagFVeXgxdieMxG1QA==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-process@3.972.9':
+    resolution: {integrity: sha512-gOWl0Fe2gETj5Bk151+LYKpeGi2lBDLNu+NMNpHRlIrKHdBmVun8/AalwMK8ci4uRfG5a3/+zvZBMpuen1SZ0A==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-sso@3.972.9':
+    resolution: {integrity: sha512-ey7S686foGTArvFhi3ifQXmgptKYvLSGE2250BAQceMSXZddz7sUSNERGJT2S7u5KIe/kgugxrt01hntXVln6w==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-web-identity@3.972.9':
+    resolution: {integrity: sha512-8LnfS76nHXoEc9aRRiMMpxZxJeDG0yusdyo3NvPhCgESmBUgpMa4luhGbClW5NoX/qRcGxxM6Z/esqANSNMTow==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/lib-storage@3.993.0':
+    resolution: {integrity: sha512-+WzMiQqtqb4Rr45YQJEu13LALaT6ba7zA7pUu4jsCCA0zcDdGBKoc24BKKrv4LG5UBXzwBG3CO0V5/LTc9t82w==}
+    engines: {node: '>=20.0.0'}
+    peerDependencies:
+      '@aws-sdk/client-s3': ^3.993.0
+
+  '@aws-sdk/middleware-bucket-endpoint@3.972.3':
+    resolution: {integrity: sha512-fmbgWYirF67YF1GfD7cg5N6HHQ96EyRNx/rDIrTF277/zTWVuPI2qS/ZHgofwR1NZPe/NWvoppflQY01LrbVLg==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/middleware-expect-continue@3.972.3':
+    resolution: {integrity: sha512-4msC33RZsXQpUKR5QR4HnvBSNCPLGHmB55oDiROqqgyOc+TOfVu2xgi5goA7ms6MdZLeEh2905UfWMnMMF4mRg==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/middleware-flexible-checksums@3.972.9':
+    resolution: {integrity: sha512-E663+r/UQpvF3aJkD40p5ZANVQFsUcbE39jifMtN7wc0t1M0+2gJJp3i75R49aY9OiSX5lfVyPUNjN/BNRCCZA==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/middleware-host-header@3.972.3':
+    resolution: {integrity: sha512-aknPTb2M+G3s+0qLCx4Li/qGZH8IIYjugHMv15JTYMe6mgZO8VBpYgeGYsNMGCqCZOcWzuf900jFBG5bopfzmA==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/middleware-location-constraint@3.972.3':
+    resolution: {integrity: sha512-nIg64CVrsXp67vbK0U1/Is8rik3huS3QkRHn2DRDx4NldrEFMgdkZGI/+cZMKD9k4YOS110Dfu21KZLHrFA/1g==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/middleware-logger@3.972.3':
+    resolution: {integrity: sha512-Ftg09xNNRqaz9QNzlfdQWfpqMCJbsQdnZVJP55jfhbKi1+FTWxGuvfPoBhDHIovqWKjqbuiew3HuhxbJ0+OjgA==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/middleware-recursion-detection@3.972.3':
+    resolution: {integrity: sha512-PY57QhzNuXHnwbJgbWYTrqIDHYSeOlhfYERTAuc16LKZpTZRJUjzBFokp9hF7u1fuGeE3D70ERXzdbMBOqQz7Q==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/middleware-sdk-s3@3.972.11':
+    resolution: {integrity: sha512-Qr0T7ZQTRMOuR6ahxEoJR1thPVovfWrKB2a6KBGR+a8/ELrFodrgHwhq50n+5VMaGuLtGhHiISU3XGsZmtmVXQ==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/middleware-ssec@3.972.3':
+    resolution: {integrity: sha512-dU6kDuULN3o3jEHcjm0c4zWJlY1zWVkjG9NPe9qxYLLpcbdj5kRYBS2DdWYD+1B9f910DezRuws7xDEqKkHQIg==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/middleware-user-agent@3.972.11':
+    resolution: {integrity: sha512-R8CvPsPHXwzIHCAza+bllY6PrctEk4lYq/SkHJz9NLoBHCcKQrbOcsfXxO6xmipSbUNIbNIUhH0lBsJGgsRdiw==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/nested-clients@3.993.0':
+    resolution: {integrity: sha512-iOq86f2H67924kQUIPOAvlmMaOAvOLoDOIb66I2YqSUpMYB6ufiuJW3RlREgskxv86S5qKzMnfy/X6CqMjK6XQ==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/region-config-resolver@3.972.3':
+    resolution: {integrity: sha512-v4J8qYAWfOMcZ4MJUyatntOicTzEMaU7j3OpkRCGGFSL2NgXQ5VbxauIyORA+pxdKZ0qQG2tCQjQjZDlXEC3Ow==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/signature-v4-multi-region@3.993.0':
+    resolution: {integrity: sha512-6l20k27TJdqTozJOm+s20/1XDey3aj+yaeIdbtqXuYNhQiWHajvYThcI1sHx2I1W4NelZTOmYEF+dj1mya01eg==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/token-providers@3.993.0':
+    resolution: {integrity: sha512-+35g4c+8r7sB9Sjp1KPdM8qxGn6B/shBjJtEUN4e+Edw9UEQlZKIzioOGu3UAbyE0a/s450LdLZr4wbJChtmww==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/types@3.973.1':
+    resolution: {integrity: sha512-DwHBiMNOB468JiX6+i34c+THsKHErYUdNQ3HexeXZvVn4zouLjgaS4FejiGSi2HyBuzuyHg7SuOPmjSvoU9NRg==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/util-arn-parser@3.972.2':
+    resolution: {integrity: sha512-VkykWbqMjlSgBFDyrY3nOSqupMc6ivXuGmvci6Q3NnLq5kC+mKQe2QBZ4nrWRE/jqOxeFP2uYzLtwncYYcvQDg==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/util-endpoints@3.993.0':
+    resolution: {integrity: sha512-j6vioBeRZ4eHX4SWGvGPpwGg/xSOcK7f1GL0VM+rdf3ZFTIsUEhCFmD78B+5r2PgztcECSzEfvHQX01k8dPQPw==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/util-locate-window@3.965.4':
+    resolution: {integrity: sha512-H1onv5SkgPBK2P6JR2MjGgbOnttoNzSPIRoeZTNPZYyaplwGg50zS3amXvXqF0/qfXpWEC9rLWU564QTB9bSog==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/util-user-agent-browser@3.972.3':
+    resolution: {integrity: sha512-JurOwkRUcXD/5MTDBcqdyQ9eVedtAsZgw5rBwktsPTN7QtPiS2Ld1jkJepNgYoCufz1Wcut9iup7GJDoIHp8Fw==}
+
+  '@aws-sdk/util-user-agent-node@3.972.9':
+    resolution: {integrity: sha512-JNswdsLdQemxqaSIBL2HRhsHPUBBziAgoi5RQv6/9avmE5g5RSdt1hWr3mHJ7OxqRYf+KeB11ExWbiqfrnoeaA==}
+    engines: {node: '>=20.0.0'}
+    peerDependencies:
+      aws-crt: '>=1.0.0'
+    peerDependenciesMeta:
+      aws-crt:
+        optional: true
+
+  '@aws-sdk/xml-builder@3.972.5':
+    resolution: {integrity: sha512-mCae5Ys6Qm1LDu0qdGwx2UQ63ONUe+FHw908fJzLDqFKTDBK4LDZUqKWm4OkTCNFq19bftjsBSESIGLD/s3/rA==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws/lambda-invoke-store@0.2.3':
+    resolution: {integrity: sha512-oLvsaPMTBejkkmHhjf09xTgk71mOqyr/409NKhRIL08If7AhVfUsJhVsx386uJaqNd42v9kWamQ9lFbkoC2dYw==}
+    engines: {node: '>=18.0.0'}
 
   '@esbuild/aix-ppc64@0.21.5':
     resolution: {integrity: sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ==}
@@ -470,6 +645,222 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@smithy/abort-controller@4.2.8':
+    resolution: {integrity: sha512-peuVfkYHAmS5ybKxWcfraK7WBBP0J+rkfUcbHJJKQ4ir3UAUNQI+Y4Vt/PqSzGqgloJ5O1dk7+WzNL8wcCSXbw==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/chunked-blob-reader-native@4.2.1':
+    resolution: {integrity: sha512-lX9Ay+6LisTfpLid2zZtIhSEjHMZoAR5hHCR4H7tBz/Zkfr5ea8RcQ7Tk4mi0P76p4cN+Btz16Ffno7YHpKXnQ==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/chunked-blob-reader@5.2.0':
+    resolution: {integrity: sha512-WmU0TnhEAJLWvfSeMxBNe5xtbselEO8+4wG0NtZeL8oR21WgH1xiO37El+/Y+H/Ie4SCwBy3MxYWmOYaGgZueA==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/config-resolver@4.4.6':
+    resolution: {integrity: sha512-qJpzYC64kaj3S0fueiu3kXm8xPrR3PcXDPEgnaNMRn0EjNSZFoFjvbUp0YUDsRhN1CB90EnHJtbxWKevnH99UQ==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/core@3.23.2':
+    resolution: {integrity: sha512-HaaH4VbGie4t0+9nY3tNBRSxVTr96wzIqexUa6C2qx3MPePAuz7lIxPxYtt1Wc//SPfJLNoZJzfdt0B6ksj2jA==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/credential-provider-imds@4.2.8':
+    resolution: {integrity: sha512-FNT0xHS1c/CPN8upqbMFP83+ul5YgdisfCfkZ86Jh2NSmnqw/AJ6x5pEogVCTVvSm7j9MopRU89bmDelxuDMYw==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/eventstream-codec@4.2.8':
+    resolution: {integrity: sha512-jS/O5Q14UsufqoGhov7dHLOPCzkYJl9QDzusI2Psh4wyYx/izhzvX9P4D69aTxcdfVhEPhjK+wYyn/PzLjKbbw==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/eventstream-serde-browser@4.2.8':
+    resolution: {integrity: sha512-MTfQT/CRQz5g24ayXdjg53V0mhucZth4PESoA5IhvaWVDTOQLfo8qI9vzqHcPsdd2v6sqfTYqF5L/l+pea5Uyw==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/eventstream-serde-config-resolver@4.3.8':
+    resolution: {integrity: sha512-ah12+luBiDGzBruhu3efNy1IlbwSEdNiw8fOZksoKoWW1ZHvO/04MQsdnws/9Aj+5b0YXSSN2JXKy/ClIsW8MQ==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/eventstream-serde-node@4.2.8':
+    resolution: {integrity: sha512-cYpCpp29z6EJHa5T9WL0KAlq3SOKUQkcgSoeRfRVwjGgSFl7Uh32eYGt7IDYCX20skiEdRffyDpvF2efEZPC0A==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/eventstream-serde-universal@4.2.8':
+    resolution: {integrity: sha512-iJ6YNJd0bntJYnX6s52NC4WFYcZeKrPUr1Kmmr5AwZcwCSzVpS7oavAmxMR7pMq7V+D1G4s9F5NJK0xwOsKAlQ==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/fetch-http-handler@5.3.9':
+    resolution: {integrity: sha512-I4UhmcTYXBrct03rwzQX1Y/iqQlzVQaPxWjCjula++5EmWq9YGBrx6bbGqluGc1f0XEfhSkiY4jhLgbsJUMKRA==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/hash-blob-browser@4.2.9':
+    resolution: {integrity: sha512-m80d/iicI7DlBDxyQP6Th7BW/ejDGiF0bgI754+tiwK0lgMkcaIBgvwwVc7OFbY4eUzpGtnig52MhPAEJ7iNYg==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/hash-node@4.2.8':
+    resolution: {integrity: sha512-7ZIlPbmaDGxVoxErDZnuFG18WekhbA/g2/i97wGj+wUBeS6pcUeAym8u4BXh/75RXWhgIJhyC11hBzig6MljwA==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/hash-stream-node@4.2.8':
+    resolution: {integrity: sha512-v0FLTXgHrTeheYZFGhR+ehX5qUm4IQsjAiL9qehad2cyjMWcN2QG6/4mSwbSgEQzI7jwfoXj7z4fxZUx/Mhj2w==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/invalid-dependency@4.2.8':
+    resolution: {integrity: sha512-N9iozRybwAQ2dn9Fot9kI6/w9vos2oTXLhtK7ovGqwZjlOcxu6XhPlpLpC+INsxktqHinn5gS2DXDjDF2kG5sQ==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/is-array-buffer@2.2.0':
+    resolution: {integrity: sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA==}
+    engines: {node: '>=14.0.0'}
+
+  '@smithy/is-array-buffer@4.2.0':
+    resolution: {integrity: sha512-DZZZBvC7sjcYh4MazJSGiWMI2L7E0oCiRHREDzIxi/M2LY79/21iXt6aPLHge82wi5LsuRF5A06Ds3+0mlh6CQ==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/md5-js@4.2.8':
+    resolution: {integrity: sha512-oGMaLj4tVZzLi3itBa9TCswgMBr7k9b+qKYowQ6x1rTyTuO1IU2YHdHUa+891OsOH+wCsH7aTPRsTJO3RMQmjQ==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/middleware-content-length@4.2.8':
+    resolution: {integrity: sha512-RO0jeoaYAB1qBRhfVyq0pMgBoUK34YEJxVxyjOWYZiOKOq2yMZ4MnVXMZCUDenpozHue207+9P5ilTV1zeda0A==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/middleware-endpoint@4.4.16':
+    resolution: {integrity: sha512-L5GICFCSsNhbJ5JSKeWFGFy16Q2OhoBizb3X2DrxaJwXSEujVvjG9Jt386dpQn2t7jINglQl0b4K/Su69BdbMA==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/middleware-retry@4.4.33':
+    resolution: {integrity: sha512-jLqZOdJhtIL4lnA9hXnAG6GgnJlo1sD3FqsTxm9wSfjviqgWesY/TMBVnT84yr4O0Vfe0jWoXlfFbzsBVph3WA==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/middleware-serde@4.2.9':
+    resolution: {integrity: sha512-eMNiej0u/snzDvlqRGSN3Vl0ESn3838+nKyVfF2FKNXFbi4SERYT6PR392D39iczngbqqGG0Jl1DlCnp7tBbXQ==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/middleware-stack@4.2.8':
+    resolution: {integrity: sha512-w6LCfOviTYQjBctOKSwy6A8FIkQy7ICvglrZFl6Bw4FmcQ1Z420fUtIhxaUZZshRe0VCq4kvDiPiXrPZAe8oRA==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/node-config-provider@4.3.8':
+    resolution: {integrity: sha512-aFP1ai4lrbVlWjfpAfRSL8KFcnJQYfTl5QxLJXY32vghJrDuFyPZ6LtUL+JEGYiFRG1PfPLHLoxj107ulncLIg==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/node-http-handler@4.4.10':
+    resolution: {integrity: sha512-u4YeUwOWRZaHbWaebvrs3UhwQwj+2VNmcVCwXcYTvPIuVyM7Ex1ftAj+fdbG/P4AkBwLq/+SKn+ydOI4ZJE9PA==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/property-provider@4.2.8':
+    resolution: {integrity: sha512-EtCTbyIveCKeOXDSWSdze3k612yCPq1YbXsbqX3UHhkOSW8zKsM9NOJG5gTIya0vbY2DIaieG8pKo1rITHYL0w==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/protocol-http@5.3.8':
+    resolution: {integrity: sha512-QNINVDhxpZ5QnP3aviNHQFlRogQZDfYlCkQT+7tJnErPQbDhysondEjhikuANxgMsZrkGeiAxXy4jguEGsDrWQ==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/querystring-builder@4.2.8':
+    resolution: {integrity: sha512-Xr83r31+DrE8CP3MqPgMJl+pQlLLmOfiEUnoyAlGzzJIrEsbKsPy1hqH0qySaQm4oWrCBlUqRt+idEgunKB+iw==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/querystring-parser@4.2.8':
+    resolution: {integrity: sha512-vUurovluVy50CUlazOiXkPq40KGvGWSdmusa3130MwrR1UNnNgKAlj58wlOe61XSHRpUfIIh6cE0zZ8mzKaDPA==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/service-error-classification@4.2.8':
+    resolution: {integrity: sha512-mZ5xddodpJhEt3RkCjbmUQuXUOaPNTkbMGR0bcS8FE0bJDLMZlhmpgrvPNCYglVw5rsYTpSnv19womw9WWXKQQ==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/shared-ini-file-loader@4.4.3':
+    resolution: {integrity: sha512-DfQjxXQnzC5UbCUPeC3Ie8u+rIWZTvuDPAGU/BxzrOGhRvgUanaP68kDZA+jaT3ZI+djOf+4dERGlm9mWfFDrg==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/signature-v4@5.3.8':
+    resolution: {integrity: sha512-6A4vdGj7qKNRF16UIcO8HhHjKW27thsxYci+5r/uVRkdcBEkOEiY8OMPuydLX4QHSrJqGHPJzPRwwVTqbLZJhg==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/smithy-client@4.11.5':
+    resolution: {integrity: sha512-xixwBRqoeP2IUgcAl3U9dvJXc+qJum4lzo3maaJxifsZxKUYLfVfCXvhT4/jD01sRrHg5zjd1cw2Zmjr4/SuKQ==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/types@4.12.0':
+    resolution: {integrity: sha512-9YcuJVTOBDjg9LWo23Qp0lTQ3D7fQsQtwle0jVfpbUHy9qBwCEgKuVH4FqFB3VYu0nwdHKiEMA+oXz7oV8X1kw==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/url-parser@4.2.8':
+    resolution: {integrity: sha512-NQho9U68TGMEU639YkXnVMV3GEFFULmmaWdlu1E9qzyIePOHsoSnagTGSDv1Zi8DCNN6btxOSdgmy5E/hsZwhA==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/util-base64@4.3.0':
+    resolution: {integrity: sha512-GkXZ59JfyxsIwNTWFnjmFEI8kZpRNIBfxKjv09+nkAWPt/4aGaEWMM04m4sxgNVWkbt2MdSvE3KF/PfX4nFedQ==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/util-body-length-browser@4.2.0':
+    resolution: {integrity: sha512-Fkoh/I76szMKJnBXWPdFkQJl2r9SjPt3cMzLdOB6eJ4Pnpas8hVoWPYemX/peO0yrrvldgCUVJqOAjUrOLjbxg==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/util-body-length-node@4.2.1':
+    resolution: {integrity: sha512-h53dz/pISVrVrfxV1iqXlx5pRg3V2YWFcSQyPyXZRrZoZj4R4DeWRDo1a7dd3CPTcFi3kE+98tuNyD2axyZReA==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/util-buffer-from@2.2.0':
+    resolution: {integrity: sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA==}
+    engines: {node: '>=14.0.0'}
+
+  '@smithy/util-buffer-from@4.2.0':
+    resolution: {integrity: sha512-kAY9hTKulTNevM2nlRtxAG2FQ3B2OR6QIrPY3zE5LqJy1oxzmgBGsHLWTcNhWXKchgA0WHW+mZkQrng/pgcCew==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/util-config-provider@4.2.0':
+    resolution: {integrity: sha512-YEjpl6XJ36FTKmD+kRJJWYvrHeUvm5ykaUS5xK+6oXffQPHeEM4/nXlZPe+Wu0lsgRUcNZiliYNh/y7q9c2y6Q==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/util-defaults-mode-browser@4.3.32':
+    resolution: {integrity: sha512-092sjYfFMQ/iaPH798LY/OJFBcYu0sSK34Oy9vdixhsU36zlZu8OcYjF3TD4e2ARupyK7xaxPXl+T0VIJTEkkg==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/util-defaults-mode-node@4.2.35':
+    resolution: {integrity: sha512-miz/ggz87M8VuM29y7jJZMYkn7+IErM5p5UgKIf8OtqVs/h2bXr1Bt3uTsREsI/4nK8a0PQERbAPsVPVNIsG7Q==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/util-endpoints@3.2.8':
+    resolution: {integrity: sha512-8JaVTn3pBDkhZgHQ8R0epwWt+BqPSLCjdjXXusK1onwJlRuN69fbvSK66aIKKO7SwVFM6x2J2ox5X8pOaWcUEw==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/util-hex-encoding@4.2.0':
+    resolution: {integrity: sha512-CCQBwJIvXMLKxVbO88IukazJD9a4kQ9ZN7/UMGBjBcJYvatpWk+9g870El4cB8/EJxfe+k+y0GmR9CAzkF+Nbw==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/util-middleware@4.2.8':
+    resolution: {integrity: sha512-PMqfeJxLcNPMDgvPbbLl/2Vpin+luxqTGPpW3NAQVLbRrFRzTa4rNAASYeIGjRV9Ytuhzny39SpyU04EQreF+A==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/util-retry@4.2.8':
+    resolution: {integrity: sha512-CfJqwvoRY0kTGe5AkQokpURNCT1u/MkRzMTASWMPPo2hNSnKtF1D45dQl3DE2LKLr4m+PW9mCeBMJr5mCAVThg==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/util-stream@4.5.12':
+    resolution: {integrity: sha512-D8tgkrmhAX/UNeCZbqbEO3uqyghUnEmmoO9YEvRuwxjlkKKUE7FOgCJnqpTlQPe9MApdWPky58mNQQHbnCzoNg==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/util-uri-escape@4.2.0':
+    resolution: {integrity: sha512-igZpCKV9+E/Mzrpq6YacdTQ0qTiLm85gD6N/IrmyDvQFA4UnU3d5g3m8tMT/6zG/vVkWSU+VxeUyGonL62DuxA==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/util-utf8@2.3.0':
+    resolution: {integrity: sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==}
+    engines: {node: '>=14.0.0'}
+
+  '@smithy/util-utf8@4.2.0':
+    resolution: {integrity: sha512-zBPfuzoI8xyBtR2P6WQj63Rz8i3AmfAaJLuNG8dWsfvPe8lO4aCPYLn879mEgHndZH1zQ2oXmG8O1GGzzaoZiw==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/util-waiter@4.2.8':
+    resolution: {integrity: sha512-n+lahlMWk+aejGuax7DPWtqav8HYnWxQwR+LCG2BgCUmaGcTe9qZCFsmw8TMg9iG75HOwhrJCX9TCJRLH+Yzqg==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/uuid@1.1.0':
+    resolution: {integrity: sha512-4aUIteuyxtBUhVdiQqcDhKFitwfd9hqoSDYY2KRXiWtgoWJ9Bmise+KfEPDiVHWeJepvF8xJO9/9+WDIciMFFw==}
+    engines: {node: '>=18.0.0'}
+
   '@types/estree@1.0.8':
     resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
 
@@ -516,9 +907,18 @@ packages:
     resolution: {integrity: sha512-1pHv8LX9CpKut1Zp4EXey7Z8OfH11ONNH6Dhi2WDUt31VVZFXZzKwXcysBgqSumFCmR+0dqjMK5v5JiFHzi0+g==}
     engines: {node: 20 || >=22}
 
+  base64-js@1.5.1:
+    resolution: {integrity: sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==}
+
+  bowser@2.14.1:
+    resolution: {integrity: sha512-tzPjzCxygAKWFOJP011oxFHs57HzIhOEracIgAePE4pqB3LikALKnSzUyU4MGs9/iCEUuHlAJTjTc5M+u7YEGg==}
+
   brace-expansion@5.0.2:
     resolution: {integrity: sha512-Pdk8c9poy+YhOgVWw1JNN22/HcivgKWwpxKq04M/jTmHyCZn12WPJebZxdjSa5TmBqISrUSgNYU3eRORljfCCw==}
     engines: {node: 20 || >=22}
+
+  buffer@5.6.0:
+    resolution: {integrity: sha512-/gDYp/UtU0eA1ys8bOs9J6a+E/KWIY+DZ+Q2WESNUA0jFRsJOc0SNUO6xJ5SGA1xueg3NL65W6s+NY5l9cunuw==}
 
   cac@6.7.14:
     resolution: {integrity: sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==}
@@ -565,9 +965,17 @@ packages:
   estree-walker@3.0.3:
     resolution: {integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==}
 
+  events@3.3.0:
+    resolution: {integrity: sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==}
+    engines: {node: '>=0.8.x'}
+
   expect-type@1.3.0:
     resolution: {integrity: sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==}
     engines: {node: '>=12.0.0'}
+
+  fast-xml-parser@5.3.6:
+    resolution: {integrity: sha512-QNI3sAvSvaOiaMl8FYU4trnEzCwiRr8XMWgAHzlrWpTSj+QaCSvOf1h82OEP1s4hiAXhnbXSyFWCf4ldZzZRVA==}
+    hasBin: true
 
   fdir@6.5.0:
     resolution: {integrity: sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==}
@@ -592,6 +1000,12 @@ packages:
     engines: {node: 20 || >=22}
     deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
     hasBin: true
+
+  ieee754@1.2.1:
+    resolution: {integrity: sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==}
+
+  inherits@2.0.4:
+    resolution: {integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==}
 
   isexe@2.0.0:
     resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
@@ -663,10 +1077,17 @@ packages:
     resolution: {integrity: sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==}
     engines: {node: ^10 || ^12 || >=14}
 
+  readable-stream@3.6.2:
+    resolution: {integrity: sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==}
+    engines: {node: '>= 6'}
+
   rollup@4.57.1:
     resolution: {integrity: sha512-oQL6lgK3e2QZeQ7gcgIkS2YZPg5slw37hYufJ3edKlfQSGGm8ICoxswK15ntSzF/a8+h7ekRy7k7oWc3BQ7y8A==}
     engines: {node: '>=18.0.0', npm: '>=8.0.0'}
     hasBin: true
+
+  safe-buffer@5.2.1:
+    resolution: {integrity: sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==}
 
   shebang-command@2.0.0:
     resolution: {integrity: sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==}
@@ -693,6 +1114,15 @@ packages:
   std-env@3.10.0:
     resolution: {integrity: sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==}
 
+  stream-browserify@3.0.0:
+    resolution: {integrity: sha512-H73RAHsVBapbim0tU2JwwOiXUj+fikfiaoYAKHF3VJfA0pe2BCzkhAHBlLG6REzE+2WNZcxOXjK7lkso+9euLA==}
+
+  string_decoder@1.3.0:
+    resolution: {integrity: sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==}
+
+  strnum@2.1.2:
+    resolution: {integrity: sha512-l63NF9y/cLROq/yqKXSLtcMeeyOfnSQlfMSlzFt/K73oIaD8DGaQWd7Z34X9GPiKqP5rbSh84Hl4bOlLcjiSrQ==}
+
   tinybench@2.9.0:
     resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
 
@@ -715,6 +1145,9 @@ packages:
     resolution: {integrity: sha512-n1cw8k1k0x4pgA2+9XrOkFydTerNcJ1zWCO5Nn9scWHTD+5tp8dghT2x1uduQePZTZgd3Tupf+x9BxJjeJi77Q==}
     engines: {node: '>=14.0.0'}
 
+  tslib@2.8.1:
+    resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
+
   typescript@5.9.3:
     resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
     engines: {node: '>=14.17'}
@@ -722,6 +1155,9 @@ packages:
 
   undici-types@6.21.0:
     resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
+
+  util-deprecate@1.0.2:
+    resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
 
   vite-node@2.1.9:
     resolution: {integrity: sha512-AM9aQ/IPrW/6ENLQg3AGY4K1N2TGZdR5e4gu/MmmR2xR3Ll1+dib+nook92g4TV3PXVyeyxdWwtaCAiUL0hMxA==}
@@ -835,6 +1271,502 @@ packages:
     hasBin: true
 
 snapshots:
+
+  '@aws-crypto/crc32@5.2.0':
+    dependencies:
+      '@aws-crypto/util': 5.2.0
+      '@aws-sdk/types': 3.973.1
+      tslib: 2.8.1
+
+  '@aws-crypto/crc32c@5.2.0':
+    dependencies:
+      '@aws-crypto/util': 5.2.0
+      '@aws-sdk/types': 3.973.1
+      tslib: 2.8.1
+
+  '@aws-crypto/sha1-browser@5.2.0':
+    dependencies:
+      '@aws-crypto/supports-web-crypto': 5.2.0
+      '@aws-crypto/util': 5.2.0
+      '@aws-sdk/types': 3.973.1
+      '@aws-sdk/util-locate-window': 3.965.4
+      '@smithy/util-utf8': 2.3.0
+      tslib: 2.8.1
+
+  '@aws-crypto/sha256-browser@5.2.0':
+    dependencies:
+      '@aws-crypto/sha256-js': 5.2.0
+      '@aws-crypto/supports-web-crypto': 5.2.0
+      '@aws-crypto/util': 5.2.0
+      '@aws-sdk/types': 3.973.1
+      '@aws-sdk/util-locate-window': 3.965.4
+      '@smithy/util-utf8': 2.3.0
+      tslib: 2.8.1
+
+  '@aws-crypto/sha256-js@5.2.0':
+    dependencies:
+      '@aws-crypto/util': 5.2.0
+      '@aws-sdk/types': 3.973.1
+      tslib: 2.8.1
+
+  '@aws-crypto/supports-web-crypto@5.2.0':
+    dependencies:
+      tslib: 2.8.1
+
+  '@aws-crypto/util@5.2.0':
+    dependencies:
+      '@aws-sdk/types': 3.973.1
+      '@smithy/util-utf8': 2.3.0
+      tslib: 2.8.1
+
+  '@aws-sdk/client-s3@3.993.0':
+    dependencies:
+      '@aws-crypto/sha1-browser': 5.2.0
+      '@aws-crypto/sha256-browser': 5.2.0
+      '@aws-crypto/sha256-js': 5.2.0
+      '@aws-sdk/core': 3.973.11
+      '@aws-sdk/credential-provider-node': 3.972.10
+      '@aws-sdk/middleware-bucket-endpoint': 3.972.3
+      '@aws-sdk/middleware-expect-continue': 3.972.3
+      '@aws-sdk/middleware-flexible-checksums': 3.972.9
+      '@aws-sdk/middleware-host-header': 3.972.3
+      '@aws-sdk/middleware-location-constraint': 3.972.3
+      '@aws-sdk/middleware-logger': 3.972.3
+      '@aws-sdk/middleware-recursion-detection': 3.972.3
+      '@aws-sdk/middleware-sdk-s3': 3.972.11
+      '@aws-sdk/middleware-ssec': 3.972.3
+      '@aws-sdk/middleware-user-agent': 3.972.11
+      '@aws-sdk/region-config-resolver': 3.972.3
+      '@aws-sdk/signature-v4-multi-region': 3.993.0
+      '@aws-sdk/types': 3.973.1
+      '@aws-sdk/util-endpoints': 3.993.0
+      '@aws-sdk/util-user-agent-browser': 3.972.3
+      '@aws-sdk/util-user-agent-node': 3.972.9
+      '@smithy/config-resolver': 4.4.6
+      '@smithy/core': 3.23.2
+      '@smithy/eventstream-serde-browser': 4.2.8
+      '@smithy/eventstream-serde-config-resolver': 4.3.8
+      '@smithy/eventstream-serde-node': 4.2.8
+      '@smithy/fetch-http-handler': 5.3.9
+      '@smithy/hash-blob-browser': 4.2.9
+      '@smithy/hash-node': 4.2.8
+      '@smithy/hash-stream-node': 4.2.8
+      '@smithy/invalid-dependency': 4.2.8
+      '@smithy/md5-js': 4.2.8
+      '@smithy/middleware-content-length': 4.2.8
+      '@smithy/middleware-endpoint': 4.4.16
+      '@smithy/middleware-retry': 4.4.33
+      '@smithy/middleware-serde': 4.2.9
+      '@smithy/middleware-stack': 4.2.8
+      '@smithy/node-config-provider': 4.3.8
+      '@smithy/node-http-handler': 4.4.10
+      '@smithy/protocol-http': 5.3.8
+      '@smithy/smithy-client': 4.11.5
+      '@smithy/types': 4.12.0
+      '@smithy/url-parser': 4.2.8
+      '@smithy/util-base64': 4.3.0
+      '@smithy/util-body-length-browser': 4.2.0
+      '@smithy/util-body-length-node': 4.2.1
+      '@smithy/util-defaults-mode-browser': 4.3.32
+      '@smithy/util-defaults-mode-node': 4.2.35
+      '@smithy/util-endpoints': 3.2.8
+      '@smithy/util-middleware': 4.2.8
+      '@smithy/util-retry': 4.2.8
+      '@smithy/util-stream': 4.5.12
+      '@smithy/util-utf8': 4.2.0
+      '@smithy/util-waiter': 4.2.8
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - aws-crt
+
+  '@aws-sdk/client-sso@3.993.0':
+    dependencies:
+      '@aws-crypto/sha256-browser': 5.2.0
+      '@aws-crypto/sha256-js': 5.2.0
+      '@aws-sdk/core': 3.973.11
+      '@aws-sdk/middleware-host-header': 3.972.3
+      '@aws-sdk/middleware-logger': 3.972.3
+      '@aws-sdk/middleware-recursion-detection': 3.972.3
+      '@aws-sdk/middleware-user-agent': 3.972.11
+      '@aws-sdk/region-config-resolver': 3.972.3
+      '@aws-sdk/types': 3.973.1
+      '@aws-sdk/util-endpoints': 3.993.0
+      '@aws-sdk/util-user-agent-browser': 3.972.3
+      '@aws-sdk/util-user-agent-node': 3.972.9
+      '@smithy/config-resolver': 4.4.6
+      '@smithy/core': 3.23.2
+      '@smithy/fetch-http-handler': 5.3.9
+      '@smithy/hash-node': 4.2.8
+      '@smithy/invalid-dependency': 4.2.8
+      '@smithy/middleware-content-length': 4.2.8
+      '@smithy/middleware-endpoint': 4.4.16
+      '@smithy/middleware-retry': 4.4.33
+      '@smithy/middleware-serde': 4.2.9
+      '@smithy/middleware-stack': 4.2.8
+      '@smithy/node-config-provider': 4.3.8
+      '@smithy/node-http-handler': 4.4.10
+      '@smithy/protocol-http': 5.3.8
+      '@smithy/smithy-client': 4.11.5
+      '@smithy/types': 4.12.0
+      '@smithy/url-parser': 4.2.8
+      '@smithy/util-base64': 4.3.0
+      '@smithy/util-body-length-browser': 4.2.0
+      '@smithy/util-body-length-node': 4.2.1
+      '@smithy/util-defaults-mode-browser': 4.3.32
+      '@smithy/util-defaults-mode-node': 4.2.35
+      '@smithy/util-endpoints': 3.2.8
+      '@smithy/util-middleware': 4.2.8
+      '@smithy/util-retry': 4.2.8
+      '@smithy/util-utf8': 4.2.0
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - aws-crt
+
+  '@aws-sdk/core@3.973.11':
+    dependencies:
+      '@aws-sdk/types': 3.973.1
+      '@aws-sdk/xml-builder': 3.972.5
+      '@smithy/core': 3.23.2
+      '@smithy/node-config-provider': 4.3.8
+      '@smithy/property-provider': 4.2.8
+      '@smithy/protocol-http': 5.3.8
+      '@smithy/signature-v4': 5.3.8
+      '@smithy/smithy-client': 4.11.5
+      '@smithy/types': 4.12.0
+      '@smithy/util-base64': 4.3.0
+      '@smithy/util-middleware': 4.2.8
+      '@smithy/util-utf8': 4.2.0
+      tslib: 2.8.1
+
+  '@aws-sdk/crc64-nvme@3.972.0':
+    dependencies:
+      '@smithy/types': 4.12.0
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-env@3.972.9':
+    dependencies:
+      '@aws-sdk/core': 3.973.11
+      '@aws-sdk/types': 3.973.1
+      '@smithy/property-provider': 4.2.8
+      '@smithy/types': 4.12.0
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-http@3.972.11':
+    dependencies:
+      '@aws-sdk/core': 3.973.11
+      '@aws-sdk/types': 3.973.1
+      '@smithy/fetch-http-handler': 5.3.9
+      '@smithy/node-http-handler': 4.4.10
+      '@smithy/property-provider': 4.2.8
+      '@smithy/protocol-http': 5.3.8
+      '@smithy/smithy-client': 4.11.5
+      '@smithy/types': 4.12.0
+      '@smithy/util-stream': 4.5.12
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-ini@3.972.9':
+    dependencies:
+      '@aws-sdk/core': 3.973.11
+      '@aws-sdk/credential-provider-env': 3.972.9
+      '@aws-sdk/credential-provider-http': 3.972.11
+      '@aws-sdk/credential-provider-login': 3.972.9
+      '@aws-sdk/credential-provider-process': 3.972.9
+      '@aws-sdk/credential-provider-sso': 3.972.9
+      '@aws-sdk/credential-provider-web-identity': 3.972.9
+      '@aws-sdk/nested-clients': 3.993.0
+      '@aws-sdk/types': 3.973.1
+      '@smithy/credential-provider-imds': 4.2.8
+      '@smithy/property-provider': 4.2.8
+      '@smithy/shared-ini-file-loader': 4.4.3
+      '@smithy/types': 4.12.0
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - aws-crt
+
+  '@aws-sdk/credential-provider-login@3.972.9':
+    dependencies:
+      '@aws-sdk/core': 3.973.11
+      '@aws-sdk/nested-clients': 3.993.0
+      '@aws-sdk/types': 3.973.1
+      '@smithy/property-provider': 4.2.8
+      '@smithy/protocol-http': 5.3.8
+      '@smithy/shared-ini-file-loader': 4.4.3
+      '@smithy/types': 4.12.0
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - aws-crt
+
+  '@aws-sdk/credential-provider-node@3.972.10':
+    dependencies:
+      '@aws-sdk/credential-provider-env': 3.972.9
+      '@aws-sdk/credential-provider-http': 3.972.11
+      '@aws-sdk/credential-provider-ini': 3.972.9
+      '@aws-sdk/credential-provider-process': 3.972.9
+      '@aws-sdk/credential-provider-sso': 3.972.9
+      '@aws-sdk/credential-provider-web-identity': 3.972.9
+      '@aws-sdk/types': 3.973.1
+      '@smithy/credential-provider-imds': 4.2.8
+      '@smithy/property-provider': 4.2.8
+      '@smithy/shared-ini-file-loader': 4.4.3
+      '@smithy/types': 4.12.0
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - aws-crt
+
+  '@aws-sdk/credential-provider-process@3.972.9':
+    dependencies:
+      '@aws-sdk/core': 3.973.11
+      '@aws-sdk/types': 3.973.1
+      '@smithy/property-provider': 4.2.8
+      '@smithy/shared-ini-file-loader': 4.4.3
+      '@smithy/types': 4.12.0
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-sso@3.972.9':
+    dependencies:
+      '@aws-sdk/client-sso': 3.993.0
+      '@aws-sdk/core': 3.973.11
+      '@aws-sdk/token-providers': 3.993.0
+      '@aws-sdk/types': 3.973.1
+      '@smithy/property-provider': 4.2.8
+      '@smithy/shared-ini-file-loader': 4.4.3
+      '@smithy/types': 4.12.0
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - aws-crt
+
+  '@aws-sdk/credential-provider-web-identity@3.972.9':
+    dependencies:
+      '@aws-sdk/core': 3.973.11
+      '@aws-sdk/nested-clients': 3.993.0
+      '@aws-sdk/types': 3.973.1
+      '@smithy/property-provider': 4.2.8
+      '@smithy/shared-ini-file-loader': 4.4.3
+      '@smithy/types': 4.12.0
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - aws-crt
+
+  '@aws-sdk/lib-storage@3.993.0(@aws-sdk/client-s3@3.993.0)':
+    dependencies:
+      '@aws-sdk/client-s3': 3.993.0
+      '@smithy/abort-controller': 4.2.8
+      '@smithy/middleware-endpoint': 4.4.16
+      '@smithy/smithy-client': 4.11.5
+      buffer: 5.6.0
+      events: 3.3.0
+      stream-browserify: 3.0.0
+      tslib: 2.8.1
+
+  '@aws-sdk/middleware-bucket-endpoint@3.972.3':
+    dependencies:
+      '@aws-sdk/types': 3.973.1
+      '@aws-sdk/util-arn-parser': 3.972.2
+      '@smithy/node-config-provider': 4.3.8
+      '@smithy/protocol-http': 5.3.8
+      '@smithy/types': 4.12.0
+      '@smithy/util-config-provider': 4.2.0
+      tslib: 2.8.1
+
+  '@aws-sdk/middleware-expect-continue@3.972.3':
+    dependencies:
+      '@aws-sdk/types': 3.973.1
+      '@smithy/protocol-http': 5.3.8
+      '@smithy/types': 4.12.0
+      tslib: 2.8.1
+
+  '@aws-sdk/middleware-flexible-checksums@3.972.9':
+    dependencies:
+      '@aws-crypto/crc32': 5.2.0
+      '@aws-crypto/crc32c': 5.2.0
+      '@aws-crypto/util': 5.2.0
+      '@aws-sdk/core': 3.973.11
+      '@aws-sdk/crc64-nvme': 3.972.0
+      '@aws-sdk/types': 3.973.1
+      '@smithy/is-array-buffer': 4.2.0
+      '@smithy/node-config-provider': 4.3.8
+      '@smithy/protocol-http': 5.3.8
+      '@smithy/types': 4.12.0
+      '@smithy/util-middleware': 4.2.8
+      '@smithy/util-stream': 4.5.12
+      '@smithy/util-utf8': 4.2.0
+      tslib: 2.8.1
+
+  '@aws-sdk/middleware-host-header@3.972.3':
+    dependencies:
+      '@aws-sdk/types': 3.973.1
+      '@smithy/protocol-http': 5.3.8
+      '@smithy/types': 4.12.0
+      tslib: 2.8.1
+
+  '@aws-sdk/middleware-location-constraint@3.972.3':
+    dependencies:
+      '@aws-sdk/types': 3.973.1
+      '@smithy/types': 4.12.0
+      tslib: 2.8.1
+
+  '@aws-sdk/middleware-logger@3.972.3':
+    dependencies:
+      '@aws-sdk/types': 3.973.1
+      '@smithy/types': 4.12.0
+      tslib: 2.8.1
+
+  '@aws-sdk/middleware-recursion-detection@3.972.3':
+    dependencies:
+      '@aws-sdk/types': 3.973.1
+      '@aws/lambda-invoke-store': 0.2.3
+      '@smithy/protocol-http': 5.3.8
+      '@smithy/types': 4.12.0
+      tslib: 2.8.1
+
+  '@aws-sdk/middleware-sdk-s3@3.972.11':
+    dependencies:
+      '@aws-sdk/core': 3.973.11
+      '@aws-sdk/types': 3.973.1
+      '@aws-sdk/util-arn-parser': 3.972.2
+      '@smithy/core': 3.23.2
+      '@smithy/node-config-provider': 4.3.8
+      '@smithy/protocol-http': 5.3.8
+      '@smithy/signature-v4': 5.3.8
+      '@smithy/smithy-client': 4.11.5
+      '@smithy/types': 4.12.0
+      '@smithy/util-config-provider': 4.2.0
+      '@smithy/util-middleware': 4.2.8
+      '@smithy/util-stream': 4.5.12
+      '@smithy/util-utf8': 4.2.0
+      tslib: 2.8.1
+
+  '@aws-sdk/middleware-ssec@3.972.3':
+    dependencies:
+      '@aws-sdk/types': 3.973.1
+      '@smithy/types': 4.12.0
+      tslib: 2.8.1
+
+  '@aws-sdk/middleware-user-agent@3.972.11':
+    dependencies:
+      '@aws-sdk/core': 3.973.11
+      '@aws-sdk/types': 3.973.1
+      '@aws-sdk/util-endpoints': 3.993.0
+      '@smithy/core': 3.23.2
+      '@smithy/protocol-http': 5.3.8
+      '@smithy/types': 4.12.0
+      tslib: 2.8.1
+
+  '@aws-sdk/nested-clients@3.993.0':
+    dependencies:
+      '@aws-crypto/sha256-browser': 5.2.0
+      '@aws-crypto/sha256-js': 5.2.0
+      '@aws-sdk/core': 3.973.11
+      '@aws-sdk/middleware-host-header': 3.972.3
+      '@aws-sdk/middleware-logger': 3.972.3
+      '@aws-sdk/middleware-recursion-detection': 3.972.3
+      '@aws-sdk/middleware-user-agent': 3.972.11
+      '@aws-sdk/region-config-resolver': 3.972.3
+      '@aws-sdk/types': 3.973.1
+      '@aws-sdk/util-endpoints': 3.993.0
+      '@aws-sdk/util-user-agent-browser': 3.972.3
+      '@aws-sdk/util-user-agent-node': 3.972.9
+      '@smithy/config-resolver': 4.4.6
+      '@smithy/core': 3.23.2
+      '@smithy/fetch-http-handler': 5.3.9
+      '@smithy/hash-node': 4.2.8
+      '@smithy/invalid-dependency': 4.2.8
+      '@smithy/middleware-content-length': 4.2.8
+      '@smithy/middleware-endpoint': 4.4.16
+      '@smithy/middleware-retry': 4.4.33
+      '@smithy/middleware-serde': 4.2.9
+      '@smithy/middleware-stack': 4.2.8
+      '@smithy/node-config-provider': 4.3.8
+      '@smithy/node-http-handler': 4.4.10
+      '@smithy/protocol-http': 5.3.8
+      '@smithy/smithy-client': 4.11.5
+      '@smithy/types': 4.12.0
+      '@smithy/url-parser': 4.2.8
+      '@smithy/util-base64': 4.3.0
+      '@smithy/util-body-length-browser': 4.2.0
+      '@smithy/util-body-length-node': 4.2.1
+      '@smithy/util-defaults-mode-browser': 4.3.32
+      '@smithy/util-defaults-mode-node': 4.2.35
+      '@smithy/util-endpoints': 3.2.8
+      '@smithy/util-middleware': 4.2.8
+      '@smithy/util-retry': 4.2.8
+      '@smithy/util-utf8': 4.2.0
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - aws-crt
+
+  '@aws-sdk/region-config-resolver@3.972.3':
+    dependencies:
+      '@aws-sdk/types': 3.973.1
+      '@smithy/config-resolver': 4.4.6
+      '@smithy/node-config-provider': 4.3.8
+      '@smithy/types': 4.12.0
+      tslib: 2.8.1
+
+  '@aws-sdk/signature-v4-multi-region@3.993.0':
+    dependencies:
+      '@aws-sdk/middleware-sdk-s3': 3.972.11
+      '@aws-sdk/types': 3.973.1
+      '@smithy/protocol-http': 5.3.8
+      '@smithy/signature-v4': 5.3.8
+      '@smithy/types': 4.12.0
+      tslib: 2.8.1
+
+  '@aws-sdk/token-providers@3.993.0':
+    dependencies:
+      '@aws-sdk/core': 3.973.11
+      '@aws-sdk/nested-clients': 3.993.0
+      '@aws-sdk/types': 3.973.1
+      '@smithy/property-provider': 4.2.8
+      '@smithy/shared-ini-file-loader': 4.4.3
+      '@smithy/types': 4.12.0
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - aws-crt
+
+  '@aws-sdk/types@3.973.1':
+    dependencies:
+      '@smithy/types': 4.12.0
+      tslib: 2.8.1
+
+  '@aws-sdk/util-arn-parser@3.972.2':
+    dependencies:
+      tslib: 2.8.1
+
+  '@aws-sdk/util-endpoints@3.993.0':
+    dependencies:
+      '@aws-sdk/types': 3.973.1
+      '@smithy/types': 4.12.0
+      '@smithy/url-parser': 4.2.8
+      '@smithy/util-endpoints': 3.2.8
+      tslib: 2.8.1
+
+  '@aws-sdk/util-locate-window@3.965.4':
+    dependencies:
+      tslib: 2.8.1
+
+  '@aws-sdk/util-user-agent-browser@3.972.3':
+    dependencies:
+      '@aws-sdk/types': 3.973.1
+      '@smithy/types': 4.12.0
+      bowser: 2.14.1
+      tslib: 2.8.1
+
+  '@aws-sdk/util-user-agent-node@3.972.9':
+    dependencies:
+      '@aws-sdk/middleware-user-agent': 3.972.11
+      '@aws-sdk/types': 3.973.1
+      '@smithy/node-config-provider': 4.3.8
+      '@smithy/types': 4.12.0
+      tslib: 2.8.1
+
+  '@aws-sdk/xml-builder@3.972.5':
+    dependencies:
+      '@smithy/types': 4.12.0
+      fast-xml-parser: 5.3.6
+      tslib: 2.8.1
+
+  '@aws/lambda-invoke-store@0.2.3': {}
 
   '@esbuild/aix-ppc64@0.21.5':
     optional: true
@@ -1062,6 +1994,344 @@ snapshots:
   '@rollup/rollup-win32-x64-msvc@4.57.1':
     optional: true
 
+  '@smithy/abort-controller@4.2.8':
+    dependencies:
+      '@smithy/types': 4.12.0
+      tslib: 2.8.1
+
+  '@smithy/chunked-blob-reader-native@4.2.1':
+    dependencies:
+      '@smithy/util-base64': 4.3.0
+      tslib: 2.8.1
+
+  '@smithy/chunked-blob-reader@5.2.0':
+    dependencies:
+      tslib: 2.8.1
+
+  '@smithy/config-resolver@4.4.6':
+    dependencies:
+      '@smithy/node-config-provider': 4.3.8
+      '@smithy/types': 4.12.0
+      '@smithy/util-config-provider': 4.2.0
+      '@smithy/util-endpoints': 3.2.8
+      '@smithy/util-middleware': 4.2.8
+      tslib: 2.8.1
+
+  '@smithy/core@3.23.2':
+    dependencies:
+      '@smithy/middleware-serde': 4.2.9
+      '@smithy/protocol-http': 5.3.8
+      '@smithy/types': 4.12.0
+      '@smithy/util-base64': 4.3.0
+      '@smithy/util-body-length-browser': 4.2.0
+      '@smithy/util-middleware': 4.2.8
+      '@smithy/util-stream': 4.5.12
+      '@smithy/util-utf8': 4.2.0
+      '@smithy/uuid': 1.1.0
+      tslib: 2.8.1
+
+  '@smithy/credential-provider-imds@4.2.8':
+    dependencies:
+      '@smithy/node-config-provider': 4.3.8
+      '@smithy/property-provider': 4.2.8
+      '@smithy/types': 4.12.0
+      '@smithy/url-parser': 4.2.8
+      tslib: 2.8.1
+
+  '@smithy/eventstream-codec@4.2.8':
+    dependencies:
+      '@aws-crypto/crc32': 5.2.0
+      '@smithy/types': 4.12.0
+      '@smithy/util-hex-encoding': 4.2.0
+      tslib: 2.8.1
+
+  '@smithy/eventstream-serde-browser@4.2.8':
+    dependencies:
+      '@smithy/eventstream-serde-universal': 4.2.8
+      '@smithy/types': 4.12.0
+      tslib: 2.8.1
+
+  '@smithy/eventstream-serde-config-resolver@4.3.8':
+    dependencies:
+      '@smithy/types': 4.12.0
+      tslib: 2.8.1
+
+  '@smithy/eventstream-serde-node@4.2.8':
+    dependencies:
+      '@smithy/eventstream-serde-universal': 4.2.8
+      '@smithy/types': 4.12.0
+      tslib: 2.8.1
+
+  '@smithy/eventstream-serde-universal@4.2.8':
+    dependencies:
+      '@smithy/eventstream-codec': 4.2.8
+      '@smithy/types': 4.12.0
+      tslib: 2.8.1
+
+  '@smithy/fetch-http-handler@5.3.9':
+    dependencies:
+      '@smithy/protocol-http': 5.3.8
+      '@smithy/querystring-builder': 4.2.8
+      '@smithy/types': 4.12.0
+      '@smithy/util-base64': 4.3.0
+      tslib: 2.8.1
+
+  '@smithy/hash-blob-browser@4.2.9':
+    dependencies:
+      '@smithy/chunked-blob-reader': 5.2.0
+      '@smithy/chunked-blob-reader-native': 4.2.1
+      '@smithy/types': 4.12.0
+      tslib: 2.8.1
+
+  '@smithy/hash-node@4.2.8':
+    dependencies:
+      '@smithy/types': 4.12.0
+      '@smithy/util-buffer-from': 4.2.0
+      '@smithy/util-utf8': 4.2.0
+      tslib: 2.8.1
+
+  '@smithy/hash-stream-node@4.2.8':
+    dependencies:
+      '@smithy/types': 4.12.0
+      '@smithy/util-utf8': 4.2.0
+      tslib: 2.8.1
+
+  '@smithy/invalid-dependency@4.2.8':
+    dependencies:
+      '@smithy/types': 4.12.0
+      tslib: 2.8.1
+
+  '@smithy/is-array-buffer@2.2.0':
+    dependencies:
+      tslib: 2.8.1
+
+  '@smithy/is-array-buffer@4.2.0':
+    dependencies:
+      tslib: 2.8.1
+
+  '@smithy/md5-js@4.2.8':
+    dependencies:
+      '@smithy/types': 4.12.0
+      '@smithy/util-utf8': 4.2.0
+      tslib: 2.8.1
+
+  '@smithy/middleware-content-length@4.2.8':
+    dependencies:
+      '@smithy/protocol-http': 5.3.8
+      '@smithy/types': 4.12.0
+      tslib: 2.8.1
+
+  '@smithy/middleware-endpoint@4.4.16':
+    dependencies:
+      '@smithy/core': 3.23.2
+      '@smithy/middleware-serde': 4.2.9
+      '@smithy/node-config-provider': 4.3.8
+      '@smithy/shared-ini-file-loader': 4.4.3
+      '@smithy/types': 4.12.0
+      '@smithy/url-parser': 4.2.8
+      '@smithy/util-middleware': 4.2.8
+      tslib: 2.8.1
+
+  '@smithy/middleware-retry@4.4.33':
+    dependencies:
+      '@smithy/node-config-provider': 4.3.8
+      '@smithy/protocol-http': 5.3.8
+      '@smithy/service-error-classification': 4.2.8
+      '@smithy/smithy-client': 4.11.5
+      '@smithy/types': 4.12.0
+      '@smithy/util-middleware': 4.2.8
+      '@smithy/util-retry': 4.2.8
+      '@smithy/uuid': 1.1.0
+      tslib: 2.8.1
+
+  '@smithy/middleware-serde@4.2.9':
+    dependencies:
+      '@smithy/protocol-http': 5.3.8
+      '@smithy/types': 4.12.0
+      tslib: 2.8.1
+
+  '@smithy/middleware-stack@4.2.8':
+    dependencies:
+      '@smithy/types': 4.12.0
+      tslib: 2.8.1
+
+  '@smithy/node-config-provider@4.3.8':
+    dependencies:
+      '@smithy/property-provider': 4.2.8
+      '@smithy/shared-ini-file-loader': 4.4.3
+      '@smithy/types': 4.12.0
+      tslib: 2.8.1
+
+  '@smithy/node-http-handler@4.4.10':
+    dependencies:
+      '@smithy/abort-controller': 4.2.8
+      '@smithy/protocol-http': 5.3.8
+      '@smithy/querystring-builder': 4.2.8
+      '@smithy/types': 4.12.0
+      tslib: 2.8.1
+
+  '@smithy/property-provider@4.2.8':
+    dependencies:
+      '@smithy/types': 4.12.0
+      tslib: 2.8.1
+
+  '@smithy/protocol-http@5.3.8':
+    dependencies:
+      '@smithy/types': 4.12.0
+      tslib: 2.8.1
+
+  '@smithy/querystring-builder@4.2.8':
+    dependencies:
+      '@smithy/types': 4.12.0
+      '@smithy/util-uri-escape': 4.2.0
+      tslib: 2.8.1
+
+  '@smithy/querystring-parser@4.2.8':
+    dependencies:
+      '@smithy/types': 4.12.0
+      tslib: 2.8.1
+
+  '@smithy/service-error-classification@4.2.8':
+    dependencies:
+      '@smithy/types': 4.12.0
+
+  '@smithy/shared-ini-file-loader@4.4.3':
+    dependencies:
+      '@smithy/types': 4.12.0
+      tslib: 2.8.1
+
+  '@smithy/signature-v4@5.3.8':
+    dependencies:
+      '@smithy/is-array-buffer': 4.2.0
+      '@smithy/protocol-http': 5.3.8
+      '@smithy/types': 4.12.0
+      '@smithy/util-hex-encoding': 4.2.0
+      '@smithy/util-middleware': 4.2.8
+      '@smithy/util-uri-escape': 4.2.0
+      '@smithy/util-utf8': 4.2.0
+      tslib: 2.8.1
+
+  '@smithy/smithy-client@4.11.5':
+    dependencies:
+      '@smithy/core': 3.23.2
+      '@smithy/middleware-endpoint': 4.4.16
+      '@smithy/middleware-stack': 4.2.8
+      '@smithy/protocol-http': 5.3.8
+      '@smithy/types': 4.12.0
+      '@smithy/util-stream': 4.5.12
+      tslib: 2.8.1
+
+  '@smithy/types@4.12.0':
+    dependencies:
+      tslib: 2.8.1
+
+  '@smithy/url-parser@4.2.8':
+    dependencies:
+      '@smithy/querystring-parser': 4.2.8
+      '@smithy/types': 4.12.0
+      tslib: 2.8.1
+
+  '@smithy/util-base64@4.3.0':
+    dependencies:
+      '@smithy/util-buffer-from': 4.2.0
+      '@smithy/util-utf8': 4.2.0
+      tslib: 2.8.1
+
+  '@smithy/util-body-length-browser@4.2.0':
+    dependencies:
+      tslib: 2.8.1
+
+  '@smithy/util-body-length-node@4.2.1':
+    dependencies:
+      tslib: 2.8.1
+
+  '@smithy/util-buffer-from@2.2.0':
+    dependencies:
+      '@smithy/is-array-buffer': 2.2.0
+      tslib: 2.8.1
+
+  '@smithy/util-buffer-from@4.2.0':
+    dependencies:
+      '@smithy/is-array-buffer': 4.2.0
+      tslib: 2.8.1
+
+  '@smithy/util-config-provider@4.2.0':
+    dependencies:
+      tslib: 2.8.1
+
+  '@smithy/util-defaults-mode-browser@4.3.32':
+    dependencies:
+      '@smithy/property-provider': 4.2.8
+      '@smithy/smithy-client': 4.11.5
+      '@smithy/types': 4.12.0
+      tslib: 2.8.1
+
+  '@smithy/util-defaults-mode-node@4.2.35':
+    dependencies:
+      '@smithy/config-resolver': 4.4.6
+      '@smithy/credential-provider-imds': 4.2.8
+      '@smithy/node-config-provider': 4.3.8
+      '@smithy/property-provider': 4.2.8
+      '@smithy/smithy-client': 4.11.5
+      '@smithy/types': 4.12.0
+      tslib: 2.8.1
+
+  '@smithy/util-endpoints@3.2.8':
+    dependencies:
+      '@smithy/node-config-provider': 4.3.8
+      '@smithy/types': 4.12.0
+      tslib: 2.8.1
+
+  '@smithy/util-hex-encoding@4.2.0':
+    dependencies:
+      tslib: 2.8.1
+
+  '@smithy/util-middleware@4.2.8':
+    dependencies:
+      '@smithy/types': 4.12.0
+      tslib: 2.8.1
+
+  '@smithy/util-retry@4.2.8':
+    dependencies:
+      '@smithy/service-error-classification': 4.2.8
+      '@smithy/types': 4.12.0
+      tslib: 2.8.1
+
+  '@smithy/util-stream@4.5.12':
+    dependencies:
+      '@smithy/fetch-http-handler': 5.3.9
+      '@smithy/node-http-handler': 4.4.10
+      '@smithy/types': 4.12.0
+      '@smithy/util-base64': 4.3.0
+      '@smithy/util-buffer-from': 4.2.0
+      '@smithy/util-hex-encoding': 4.2.0
+      '@smithy/util-utf8': 4.2.0
+      tslib: 2.8.1
+
+  '@smithy/util-uri-escape@4.2.0':
+    dependencies:
+      tslib: 2.8.1
+
+  '@smithy/util-utf8@2.3.0':
+    dependencies:
+      '@smithy/util-buffer-from': 2.2.0
+      tslib: 2.8.1
+
+  '@smithy/util-utf8@4.2.0':
+    dependencies:
+      '@smithy/util-buffer-from': 4.2.0
+      tslib: 2.8.1
+
+  '@smithy/util-waiter@4.2.8':
+    dependencies:
+      '@smithy/abort-controller': 4.2.8
+      '@smithy/types': 4.12.0
+      tslib: 2.8.1
+
+  '@smithy/uuid@1.1.0':
+    dependencies:
+      tslib: 2.8.1
+
   '@types/estree@1.0.8': {}
 
   '@types/mime-types@2.1.4': {}
@@ -1114,9 +2384,18 @@ snapshots:
 
   balanced-match@4.0.3: {}
 
+  base64-js@1.5.1: {}
+
+  bowser@2.14.1: {}
+
   brace-expansion@5.0.2:
     dependencies:
       balanced-match: 4.0.3
+
+  buffer@5.6.0:
+    dependencies:
+      base64-js: 1.5.1
+      ieee754: 1.2.1
 
   cac@6.7.14: {}
 
@@ -1203,7 +2482,13 @@ snapshots:
     dependencies:
       '@types/estree': 1.0.8
 
+  events@3.3.0: {}
+
   expect-type@1.3.0: {}
+
+  fast-xml-parser@5.3.6:
+    dependencies:
+      strnum: 2.1.2
 
   fdir@6.5.0(picomatch@4.0.3):
     optionalDependencies:
@@ -1225,6 +2510,10 @@ snapshots:
       minipass: 7.1.3
       package-json-from-dist: 1.0.1
       path-scurry: 2.0.1
+
+  ieee754@1.2.1: {}
+
+  inherits@2.0.4: {}
 
   isexe@2.0.0: {}
 
@@ -1279,6 +2568,12 @@ snapshots:
       picocolors: 1.1.1
       source-map-js: 1.2.1
 
+  readable-stream@3.6.2:
+    dependencies:
+      inherits: 2.0.4
+      string_decoder: 1.3.0
+      util-deprecate: 1.0.2
+
   rollup@4.57.1:
     dependencies:
       '@types/estree': 1.0.8
@@ -1310,6 +2605,8 @@ snapshots:
       '@rollup/rollup-win32-x64-msvc': 4.57.1
       fsevents: 2.3.3
 
+  safe-buffer@5.2.1: {}
+
   shebang-command@2.0.0:
     dependencies:
       shebang-regex: 3.0.0
@@ -1326,6 +2623,17 @@ snapshots:
 
   std-env@3.10.0: {}
 
+  stream-browserify@3.0.0:
+    dependencies:
+      inherits: 2.0.4
+      readable-stream: 3.6.2
+
+  string_decoder@1.3.0:
+    dependencies:
+      safe-buffer: 5.2.1
+
+  strnum@2.1.2: {}
+
   tinybench@2.9.0: {}
 
   tinyexec@0.3.2: {}
@@ -1341,9 +2649,13 @@ snapshots:
 
   tinyspy@3.0.2: {}
 
+  tslib@2.8.1: {}
+
   typescript@5.9.3: {}
 
   undici-types@6.21.0: {}
+
+  util-deprecate@1.0.2: {}
 
   vite-node@2.1.9(@types/node@22.19.11):
     dependencies:


### PR DESCRIPTION
## 概要

`static3d-deploy push` コマンドの完全実装。
ビルド済みの `dist/pages/` と `dist/cdn/` を Cloudflare R2 + Pages に原子的にデプロイする。

---

## 新規実装ファイル

### `config/auth.ts` — 認証情報解決
```
CLOUDFLARE_ACCOUNT_ID          R2 + Pages 共用
CLOUDFLARE_R2_ACCESS_KEY_ID    R2 専用
CLOUDFLARE_R2_SECRET_ACCESS_KEY R2 専用
CLOUDFLARE_API_TOKEN           Pages 専用
```
- 未設定の場合は環境変数名を含む `AuthError` で即失敗
- R2エンドポイント自動構築: `https://<accountId>.r2.cloudflarestorage.com`

### `push/diff.ts` — 差分計算
- R2の全オブジェクト一覧を取得してローカルキーと比較
- コンテンツハッシュ名なので **同名ファイル = 同一内容が保証** → 既存キーは無条件スキップ
- `ContinuationToken` でページネーション完全対応

### `push/r2.ts` — R2アップロード
- 5MB未満: `PutObjectCommand`
- 5MB以上: `@aws-sdk/lib-storage` マルチパートアップロード
- `Cache-Control: public, max-age=31536000, immutable` (コンテンツハッシュ名なので永続キャッシュ)
- `deleteFromR2()`: 1000件チャンクでバッチ削除

### `push/pages.ts` — Pages Direct Upload
- プロジェクト存在確認 + なければ自動作成
- `dist/pages/` 全ファイルを `multipart/form-data` で一括送信
- Cloudflare REST API 直叩き（wrangler不要）

### `push/cleanup.ts` — 旧世代クリーンアップ
- 現マニフェストに含まれないR2キーを削除
- `oldVersionRetention > 0` のときはスキップ（警告のみ、将来実装）

### `push/index.ts` — オーケストレーション
実行順序による **原子性保証**:
```
1. 前提条件チェック (dist/pages, manifest.json, dist/cdn)
2. R2 疎通確認
3. R2 差分アップロード ← CDN アセット全部が先に存在する
4. Pages デプロイ     ← manifest 配信開始時点で CDN は準備完了
5. 旧世代クリーンアップ
```

### `cli/push.ts` / `cli/validate.ts` — CLI
```
static3d-deploy push [--project <name>] [--skip-cleanup] [--skip-pages]
static3d-deploy validate [--config <path>]
```
`validate` は config / ディレクトリ / アセット / 環境変数を全チェック。
環境変数未設定は **警告のみ**（`push`前の事前確認用なのでエラーにしない）。

---

## テスト: 20 → 32 passed

| テストファイル | テスト数 | カバー内容 |
|---|---|---|
| `auth.test.ts` | 6 | env var解決 / AuthError / endpoint構築 |
| `diff.test.ts` | 3 | 差分計算 / 空バケット / 空ローカル |
| `cleanup.test.ts` | 3 | 旧世代削除 / 全保持 / retention>0スキップ |

---

## validate コマンドの実行例
```
$ static3d-deploy validate

[VALIDATE] Checking static3d.config.json...

  ✓ Config file loaded
  ✓ schemaVersion: 1
  ✓ project: "my-cake-shop"
  ✓ Deploy config valid
  ✓ cdn.baseUrl: https://cdn.example.com
  ✓ immediateDir exists: src/assets/immediate
  ✓ deferredDir exists: src/assets/deferred
  ✓ Deferred assets: 4 file(s) found
  ✓   1 .gltf file(s) will be rewritten

[VALIDATE] Checking environment variables...

  ⚠ CLOUDFLARE_ACCOUNT_ID: not set (required for "push" command)
  ...

[VALIDATE] ✓ All checks passed
```

---

## Phase 1 完了基準の充足
> `vite build` で dist/pages + dist/cdn が生成され、`static3d deploy push` で Cloudflare に配置される。

- ✅ `static3d-deploy build` → dist/pages + dist/cdn
- ✅ `static3d-deploy push` → R2 + Pages へデプロイ（認証情報があれば即使える）
- ✅ `static3d-deploy validate` → デプロイ前の事前確認
- ✅ Vite プラグイン → dev時ローカルCDN / build時パイプライン自動実行