### PR TITLE
feat(phase2): @static3d/display 実装 — ローダー + React hooks + Sceneコンポーネント

### DIFF
--- a/packages/display/package.json
+++ b/packages/display/package.json
@@ -1,0 +1,60 @@
+{
+  "name": "@static3d/display",
+  "version": "0.1.0",
+  "type": "module",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    }
+  },
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "tsc",
+    "dev": "tsc --watch",
+    "test": "vitest run"
+  },
+  "dependencies": {
+    "@static3d/types": "workspace:*"
+  },
+  "peerDependencies": {
+    "@react-three/drei": ">=9",
+    "@react-three/fiber": ">=8",
+    "react": ">=18",
+    "react-dom": ">=18",
+    "three": ">=0.160"
+  },
+  "peerDependenciesMeta": {
+    "react": {
+      "optional": true
+    },
+    "react-dom": {
+      "optional": true
+    },
+    "@react-three/fiber": {
+      "optional": true
+    },
+    "@react-three/drei": {
+      "optional": true
+    },
+    "three": {
+      "optional": true
+    }
+  },
+  "devDependencies": {
+    "@react-three/drei": "^9.0.0",
+    "@react-three/fiber": "^9.0.0",
+    "@types/react": "^19.0.0",
+    "@types/three": "^0.172.0",
+    "happy-dom": "^20.6.3",
+    "react": "^19.0.0",
+    "react-dom": "^19.0.0",
+    "three": "^0.172.0",
+    "typescript": "^5.7.0",
+    "vitest": "^2.0.0"
+  }
+}

--- a/packages/display/src/index.ts
+++ b/packages/display/src/index.ts
@@ -1,0 +1,58 @@
+/**
+ * @static3d/display — public API
+ *
+ * ブラウザ専用パッケージ。
+ * manifest.json を読んで CDN からアセットを fetch するローダーと、
+ * React/R3F ベースの 3D 空間コンポーネントを提供する。
+ *
+ * Node.js モジュール（fs, path 等）は一切使わない。
+ */
+
+// ── Loader ───────────────────────────────────────────────────────────────
+export { AssetLoader } from './loader/AssetLoader.js';
+export type { AssetMap } from './loader/types.js';
+
+// ── React hooks & Provider ───────────────────────────────────────────────
+export {
+  AssetProvider,
+  useAssetContext,
+} from './react/AssetProvider.js';
+export type {
+  AssetProviderProps,
+  AssetContextValue,
+} from './react/AssetProvider.js';
+
+export { useAsset, clearAssetCache } from './react/useAsset.js';
+
+export { useAssetProgress } from './react/useAssetProgress.js';
+export type { ProgressState } from './react/useAssetProgress.js';
+
+// ── Scene components ─────────────────────────────────────────────────────
+export { Stage } from './scene/Stage.js';
+export { Room, useRoom } from './scene/Room.js';
+export type { RoomContextValue } from './scene/Room.js';
+export { Spot } from './scene/Spot.js';
+export { Overlay } from './scene/Overlay.js';
+
+// ── Camera engine ────────────────────────────────────────────────────────
+export { CameraEngine } from './scene/engine/CameraEngine.js';
+export type { CameraEngineState } from './scene/engine/CameraEngine.js';
+
+// ── Types (re-export from @static3d/types) ───────────────────────────────
+export type {
+  LoaderOptions,
+  LoadOptions,
+  LoadAllOptions,
+  ProgressEvent,
+  LoadError,
+  AssetResult,
+  Vec3,
+  CameraState,
+  TransitionConfig,
+  StageProps,
+  RoomProps,
+  SpotProps,
+  SpotHighlight,
+  OverlayProps,
+  OverlayAnchor,
+} from '@static3d/types';

--- a/packages/display/src/loader/AssetLoader.ts
+++ b/packages/display/src/loader/AssetLoader.ts
@@ -1,0 +1,413 @@
+/**
+ * AssetLoader.ts
+ *
+ * manifest.json を読み込み、CDN から 3D アセットを fetch するローダー。
+ * ブラウザ専用（Node.js の fs / path 等は一切使わない）。
+ *
+ * 機能:
+ *   - manifest.json 取得 & キャッシュ
+ *   - 同時ダウンロード数制御（concurrency）
+ *   - 指数バックオフ付きリトライ
+ *   - タイムアウト（AbortSignal + setTimeout）
+ *   - SRI ハッシュ検証（SubtleCrypto、integrity オプション）
+ *   - 進捗コールバック（onProgress）
+ *   - エラーコールバック（onError）
+ *   - 全体キャンセル（cancel）
+ */
+import type { DeployManifest } from '@static3d/types';
+import type {
+  LoaderOptions,
+  LoadOptions,
+  LoadAllOptions,
+  ProgressEvent,
+  LoadError,
+  AssetMap,
+} from './types.js';
+
+// ────────────────────────────────────────────────────────────────────────────
+// デフォルト設定
+// ────────────────────────────────────────────────────────────────────────────
+
+const DEFAULT_OPTIONS: Required<LoaderOptions> = {
+  concurrency: 4,
+  retryCount: 3,
+  retryDelay: 1000,
+  timeout: 30_000,
+  integrity: true,
+};
+
+// ────────────────────────────────────────────────────────────────────────────
+// ユーティリティ
+// ────────────────────────────────────────────────────────────────────────────
+
+/** "sha256:<hex64>" から SubresourceIntegrity 文字列 "sha256-<base64>" を生成 */
+function toSriString(hash: string): string | null {
+  // hash は "sha256:<64 hex chars>"
+  const m = hash.match(/^sha256:([0-9a-f]{64})$/i);
+  if (!m) return null;
+  const bytes = new Uint8Array(32);
+  for (let i = 0; i < 32; i++) {
+    bytes[i] = parseInt(m[1].slice(i * 2, i * 2 + 2), 16);
+  }
+  // base64 encode
+  let bin = '';
+  bytes.forEach((b) => (bin += String.fromCharCode(b)));
+  return 'sha256-' + btoa(bin);
+}
+
+/**
+ * SubtleCrypto で Blob の SHA-256 を計算し、manifest の hash と照合する。
+ * hash 形式: "sha256:<hex64>"
+ */
+async function verifyIntegrity(data: ArrayBuffer, hash: string): Promise<void> {
+  const m = hash.match(/^sha256:([0-9a-f]{64})$/i);
+  if (!m) return; // 検証不能な形式はスキップ
+
+  const digest = await crypto.subtle.digest('SHA-256', data);
+  const hex = Array.from(new Uint8Array(digest))
+    .map((b) => b.toString(16).padStart(2, '0'))
+    .join('');
+
+  if (hex.toLowerCase() !== m[1].toLowerCase()) {
+    throw new Error(`Integrity check failed: expected ${m[1]}, got ${hex}`);
+  }
+}
+
+/** contentType から responseType を推定 */
+function inferResponseType(
+  contentType: string
+): 'blob' | 'arraybuffer' | 'json' {
+  if (contentType === 'application/json' || contentType.endsWith('+json')) {
+    return 'json';
+  }
+  if (
+    contentType.startsWith('text/') ||
+    contentType === 'application/javascript'
+  ) {
+    return 'blob';
+  }
+  return 'arraybuffer';
+}
+
+/** delay helper */
+const delay = (ms: number): Promise<void> =>
+  new Promise((r) => setTimeout(r, ms));
+
+// ────────────────────────────────────────────────────────────────────────────
+// AssetLoader
+// ────────────────────────────────────────────────────────────────────────────
+
+export class AssetLoader {
+  private readonly manifestUrl: string;
+  private readonly opts: Required<LoaderOptions>;
+
+  private manifest: DeployManifest | null = null;
+  private cancelled = false;
+
+  private progressCallbacks: Array<(e: ProgressEvent) => void> = [];
+  private errorCallbacks: Array<(e: LoadError) => void> = [];
+
+  /** 進捗トラッキング */
+  private loadedBytes = 0;
+  private totalBytes = 0;
+  private completedCount = 0;
+  private totalCount = 0;
+
+  constructor(manifestUrl: string, options?: LoaderOptions) {
+    this.manifestUrl = manifestUrl;
+    this.opts = { ...DEFAULT_OPTIONS, ...options };
+  }
+
+  // ── パブリック API ─────────────────────────────────────────────────────
+
+  /**
+   * manifest.json を fetch して内部にキャッシュする。
+   * loadAll / load より先に呼ぶ必要はないが、呼ぶと事前に取得できる。
+   */
+  async init(): Promise<void> {
+    await this.fetchManifest();
+  }
+
+  /**
+   * 単一アセットを取得する。
+   * @param key deferredDir からの相対パス（例: 'models/scene.gltf'）
+   */
+  async load(
+    key: string,
+    options?: LoadOptions
+  ): Promise<Blob | ArrayBuffer> {
+    const manifest = await this.fetchManifest();
+    const entry = manifest.assets[key];
+    if (!entry) {
+      const err: LoadError = {
+        type: 'not-found',
+        key,
+        url: '',
+        cause: new Error(`Asset "${key}" not found in manifest`),
+      };
+      this.emitError(err);
+      throw err;
+    }
+
+    return this.fetchAsset(key, entry.url, entry, options);
+  }
+
+  /**
+   * manifest に含まれる全アセット（または keys で絞り込んだ）を取得する。
+   * concurrency 制限付きで並列ダウンロード。
+   */
+  async loadAll(options?: LoadAllOptions): Promise<AssetMap> {
+    const manifest = await this.fetchManifest();
+
+    const keys = options?.keys
+      ? options.keys
+      : Object.keys(manifest.assets);
+
+    // 進捗初期化
+    this.totalCount = keys.length;
+    this.completedCount = 0;
+    this.loadedBytes = 0;
+    this.totalBytes = keys.reduce(
+      (sum, k) => sum + (manifest.assets[k]?.size ?? 0),
+      0
+    );
+
+    const result: AssetMap = new Map();
+    const errors: LoadError[] = [];
+
+    // TODO(phase3): 個別アセットに priority を付けて loadAll でソートする。
+    // 現状の LoadAllOptions.priority は全エントリに共通の値なので
+    // sort しても順番が変わらない（全要素の比較値が同じ）。
+    // Phase 3 では AssetEntry に priority フィールドを追加し、
+    // high → normal → low の順で処理するキューを実装する予定。
+    // ref: https://github.com/Gominokas/static3d/issues (priority queuing)
+    const queue = [...keys];
+
+    // concurrency 制御
+    let idx = 0;
+
+    const worker = async (): Promise<void> => {
+      while (idx < queue.length) {
+        if (this.cancelled) break;
+        const key = queue[idx++];
+        const entry = manifest.assets[key];
+        if (!entry) continue;
+
+        try {
+          const data = await this.fetchAsset(key, entry.url, entry, options);
+          result.set(key, data instanceof ArrayBuffer ? new Blob([data]) : data as Blob);
+        } catch (err) {
+          if ((err as LoadError).type) {
+            errors.push(err as LoadError);
+          }
+        }
+      }
+    };
+
+    const workers = Array.from(
+      { length: Math.min(this.opts.concurrency, queue.length) },
+      () => worker()
+    );
+    await Promise.all(workers);
+
+    return result;
+  }
+
+  /** 進捗コールバックを登録 */
+  onProgress(callback: (event: ProgressEvent) => void): void {
+    this.progressCallbacks.push(callback);
+  }
+
+  /** エラーコールバックを登録 */
+  onError(callback: (error: LoadError) => void): void {
+    this.errorCallbacks.push(callback);
+  }
+
+  /** 進行中のダウンロードをすべてキャンセル */
+  cancel(): void {
+    this.cancelled = true;
+  }
+
+  /** manifest を取得する（キャッシュあれば使い回す） */
+  getManifest(): DeployManifest | null {
+    return this.manifest;
+  }
+
+  // ── プライベート ───────────────────────────────────────────────────────
+
+  private async fetchManifest(): Promise<DeployManifest> {
+    if (this.manifest) return this.manifest;
+
+    const controller = new AbortController();
+    const timer = setTimeout(
+      () => controller.abort(),
+      this.opts.timeout
+    );
+
+    try {
+      const res = await fetch(this.manifestUrl, {
+        signal: controller.signal,
+        cache: 'no-store', // manifest は常に最新を取得
+      });
+
+      if (!res.ok) {
+        throw new Error(`HTTP ${res.status}: ${this.manifestUrl}`);
+      }
+
+      this.manifest = (await res.json()) as DeployManifest;
+      return this.manifest;
+    } catch (e) {
+      const err: LoadError = {
+        type: e instanceof DOMException && e.name === 'AbortError'
+          ? 'timeout'
+          : 'network',
+        key: '__manifest__',
+        url: this.manifestUrl,
+        cause: e instanceof Error ? e : new Error(String(e)),
+      };
+      this.emitError(err);
+      throw err;
+    } finally {
+      clearTimeout(timer);
+    }
+  }
+
+  /**
+   * 単一ファイルをリトライ付きで fetch する。
+   * タイムアウト・整合性チェック・進捗通知を行う。
+   */
+  private async fetchAsset(
+    key: string,
+    url: string,
+    entry: { size: number; hash: string; contentType: string },
+    options?: LoadOptions
+  ): Promise<Blob | ArrayBuffer> {
+    if (this.cancelled) {
+      const err: LoadError = { type: 'abort', key, url };
+      throw err;
+    }
+
+    const responseType =
+      options?.responseType ?? inferResponseType(entry.contentType);
+    const maxAttempts = this.opts.retryCount + 1;
+
+    for (let attempt = 0; attempt < maxAttempts; attempt++) {
+      if (this.cancelled) {
+        const err: LoadError = { type: 'abort', key, url };
+        throw err;
+      }
+
+      // タイムアウト + 外部 AbortSignal を合成
+      const controller = new AbortController();
+      const timer = setTimeout(
+        () => controller.abort(),
+        this.opts.timeout
+      );
+      const externalAbort = () => controller.abort();
+      options?.signal?.addEventListener('abort', externalAbort);
+
+      try {
+        const res = await fetch(url, {
+          signal: controller.signal,
+        });
+
+        if (!res.ok) {
+          throw Object.assign(new Error(`HTTP ${res.status}`), {
+            statusCode: res.status,
+          });
+        }
+
+        const buffer = await res.arrayBuffer();
+
+        // SRI 整合性チェック
+        if (this.opts.integrity && entry.hash) {
+          try {
+            await verifyIntegrity(buffer, entry.hash);
+          } catch (integrityErr) {
+            const err: LoadError = {
+              type: 'integrity',
+              key,
+              url,
+              cause:
+                integrityErr instanceof Error
+                  ? integrityErr
+                  : new Error(String(integrityErr)),
+            };
+            this.emitError(err);
+            throw err;
+          }
+        }
+
+        // 進捗更新
+        this.loadedBytes += entry.size;
+        this.completedCount++;
+        this.emitProgress(key);
+
+        // 要求された形式に変換
+        if (responseType === 'json') {
+          const text = new TextDecoder().decode(buffer);
+          return new Blob([text], { type: 'application/json' });
+        }
+        if (responseType === 'blob') {
+          return new Blob([buffer], { type: entry.contentType });
+        }
+        return buffer; // arraybuffer
+
+      } catch (e) {
+        options?.signal?.removeEventListener('abort', externalAbort);
+        clearTimeout(timer);
+
+        const isAbort = e instanceof DOMException && e.name === 'AbortError';
+        const isTimeout = isAbort && !options?.signal?.aborted;
+
+        // 外部からの abort は即リトライせずスロー
+        if (isAbort && options?.signal?.aborted) {
+          const err: LoadError = { type: 'abort', key, url };
+          this.emitError(err);
+          throw err;
+        }
+
+        // integrity エラーはリトライしない
+        if ((e as LoadError).type === 'integrity') throw e;
+
+        // 最後の試行 → エラーをスロー
+        if (attempt === maxAttempts - 1) {
+          const err: LoadError = {
+            type: isTimeout ? 'timeout' : 'network',
+            key,
+            url,
+            cause: e instanceof Error ? e : new Error(String(e)),
+            statusCode: (e as { statusCode?: number }).statusCode,
+          };
+          this.emitError(err);
+          throw err;
+        }
+
+        // 指数バックオフで待機してリトライ
+        await delay(this.opts.retryDelay * Math.pow(2, attempt));
+        continue;
+      } finally {
+        clearTimeout(timer);
+        options?.signal?.removeEventListener('abort', externalAbort);
+      }
+    }
+
+    // ここには到達しないが TypeScript を満足させる
+    throw new Error('Unreachable');
+  }
+
+  private emitProgress(currentKey: string): void {
+    const event: ProgressEvent = {
+      loaded: this.loadedBytes,
+      total: this.totalBytes,
+      asset: currentKey,
+      completedCount: this.completedCount,
+      totalCount: this.totalCount,
+    };
+    this.progressCallbacks.forEach((cb) => cb(event));
+  }
+
+  private emitError(err: LoadError): void {
+    this.errorCallbacks.forEach((cb) => cb(err));
+  }
+}

--- a/packages/display/src/loader/types.ts
+++ b/packages/display/src/loader/types.ts
@@ -1,0 +1,32 @@
+/**
+ * loader/types.ts
+ *
+ * @static3d/types の型を re-export しつつ、
+ * display パッケージ内部で使うローダー専用型を追加定義する。
+ */
+export type {
+  LoaderOptions,
+  LoadOptions,
+  LoadAllOptions,
+  ProgressEvent,
+  LoadError,
+  AssetResult,
+} from '@static3d/types';
+
+import type { LoadError } from '@static3d/types';
+
+/** ダウンロードキューに積む内部エントリ */
+export interface QueueEntry {
+  key: string;
+  url: string;
+  contentType: string;
+  sizeInBytes: number;
+  priority: 'high' | 'normal' | 'low';
+  resolve: (value: Blob | ArrayBuffer) => void;
+  reject: (reason: LoadError) => void;
+  signal?: AbortSignal;
+  responseType: 'blob' | 'arraybuffer' | 'json';
+}
+
+/** loadAll の戻り値マップ */
+export type AssetMap = Map<string, Blob>;

--- a/packages/display/src/react/AssetProvider.tsx
+++ b/packages/display/src/react/AssetProvider.tsx
@@ -1,0 +1,101 @@
+/**
+ * AssetProvider.tsx
+ *
+ * AssetLoader を React Context で提供する Provider。
+ * manifestUrl を受け取り、子コンポーネントに loader を配布する。
+ */
+import React, {
+  createContext,
+  useContext,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from 'react';
+import { AssetLoader } from '../loader/AssetLoader.js';
+import type { LoaderOptions, ProgressEvent } from '@static3d/types';
+
+// ────────────────────────────────────────────────────────────────────────────
+// Context
+// ────────────────────────────────────────────────────────────────────────────
+
+export interface AssetContextValue {
+  loader: AssetLoader;
+  /** manifest 取得済みか */
+  ready: boolean;
+  /** manifest 取得エラー */
+  error: Error | null;
+  /** 現在の進捗 */
+  progress: ProgressEvent | null;
+}
+
+const AssetContext = createContext<AssetContextValue | null>(null);
+
+// ────────────────────────────────────────────────────────────────────────────
+// Provider
+// ────────────────────────────────────────────────────────────────────────────
+
+export interface AssetProviderProps {
+  manifestUrl: string;
+  options?: LoaderOptions;
+  children?: React.ReactNode;
+}
+
+export function AssetProvider({
+  manifestUrl,
+  options,
+  children,
+}: AssetProviderProps): React.JSX.Element {
+  const [ready, setReady] = useState(false);
+  const [error, setError] = useState<Error | null>(null);
+  const [progress, setProgress] = useState<ProgressEvent | null>(null);
+
+  // manifestUrl or options が変わったら loader を再生成
+  const loader = useMemo(
+    () => new AssetLoader(manifestUrl, options),
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [manifestUrl, JSON.stringify(options)]
+  );
+
+  useEffect(() => {
+    setReady(false);
+    setError(null);
+
+    loader.onProgress((e) => setProgress(e));
+
+    loader
+      .init()
+      .then(() => setReady(true))
+      .catch((e: unknown) => {
+        setError(e instanceof Error ? e : new Error(String(e)));
+      });
+
+    return () => {
+      loader.cancel();
+    };
+  }, [loader]);
+
+  const value = useMemo<AssetContextValue>(
+    () => ({ loader, ready, error, progress }),
+    [loader, ready, error, progress]
+  );
+
+  return (
+    <AssetContext.Provider value={value}>{children}</AssetContext.Provider>
+  );
+}
+
+// ────────────────────────────────────────────────────────────────────────────
+// hook: useAssetContext
+// ────────────────────────────────────────────────────────────────────────────
+
+/** AssetContext を取得する。Provider の外で使うと例外をスロー。 */
+export function useAssetContext(): AssetContextValue {
+  const ctx = useContext(AssetContext);
+  if (!ctx) {
+    throw new Error(
+      '[static3d] useAssetContext must be used inside <AssetProvider>'
+    );
+  }
+  return ctx;
+}

--- a/packages/display/src/react/useAsset.ts
+++ b/packages/display/src/react/useAsset.ts
@@ -1,0 +1,106 @@
+/**
+ * useAsset.ts
+ *
+ * 単一アセットを取得する Suspense 対応フック。
+ *
+ * 使い方:
+ *   const { data, url, contentType } = useAsset('models/scene.gltf');
+ *
+ * Suspense ラッパーで囲む:
+ *   <Suspense fallback={<Loading />}>
+ *     <MyComponent />   ← useAsset を呼ぶ
+ *   </Suspense>
+ */
+import { use, useMemo } from 'react';
+import { useAssetContext } from './AssetProvider.js';
+import type { LoadOptions, AssetResult } from '@static3d/types';
+
+// ────────────────────────────────────────────────────────────────────────────
+// Promise cache（Suspense 用）
+// ────────────────────────────────────────────────────────────────────────────
+
+type CacheEntry =
+  | { status: 'pending'; promise: Promise<void> }
+  | { status: 'resolved'; value: Blob | ArrayBuffer }
+  | { status: 'rejected'; reason: unknown };
+
+const cache = new Map<string, CacheEntry>();
+
+function getCacheKey(manifestUrl: string, assetKey: string, opts?: LoadOptions): string {
+  return `${manifestUrl}::${assetKey}::${opts?.responseType ?? ''}`;
+}
+
+// ────────────────────────────────────────────────────────────────────────────
+// useAsset
+// ────────────────────────────────────────────────────────────────────────────
+
+/**
+ * Suspense 対応。manifest が ready になるまで Promise を throw する。
+ * アセット fetch 中も Promise を throw → Suspense の fallback が表示される。
+ */
+export function useAsset<T = Blob>(
+  key: string,
+  options?: LoadOptions
+): AssetResult<T> {
+  const { loader, ready, error } = useAssetContext();
+
+  // manifest エラーは直接 throw
+  if (error) throw error;
+
+  const manifestUrl = loader['manifestUrl'] as string;
+  const cacheKey = getCacheKey(manifestUrl, key, options);
+
+  // キャッシュが存在しない or pending の場合は Promise を throw (Suspense)
+  if (!ready) {
+    // まだ manifest 未取得 → 空 Promise を throw して再 render を待つ
+    const pending: CacheEntry = {
+      status: 'pending',
+      promise: new Promise(() => {
+        // この Promise は解決されない — ready になると再 render される
+      }),
+    };
+    throw pending.promise;
+  }
+
+  // キャッシュ確認
+  let entry = cache.get(cacheKey);
+
+  if (!entry) {
+    // 初回: fetch を開始してキャッシュに pending を積む
+    const promise = loader
+      .load(key, options)
+      .then((data) => {
+        cache.set(cacheKey, { status: 'resolved', value: data });
+      })
+      .catch((reason: unknown) => {
+        cache.set(cacheKey, { status: 'rejected', reason });
+      });
+
+    entry = { status: 'pending', promise };
+    cache.set(cacheKey, entry);
+  }
+
+  if (entry.status === 'pending') {
+    throw entry.promise;
+  }
+
+  if (entry.status === 'rejected') {
+    throw entry.reason;
+  }
+
+  // resolved
+  const manifest = loader.getManifest();
+  const assetEntry = manifest?.assets[key];
+
+  return {
+    data: entry.value as T,
+    key,
+    url: assetEntry?.url ?? '',
+    contentType: assetEntry?.contentType ?? 'application/octet-stream',
+  };
+}
+
+/** キャッシュを手動でクリア（テスト用途など） */
+export function clearAssetCache(): void {
+  cache.clear();
+}

--- a/packages/display/src/react/useAssetProgress.ts
+++ b/packages/display/src/react/useAssetProgress.ts
@@ -1,0 +1,58 @@
+/**
+ * useAssetProgress.ts
+ *
+ * ローダーの全体進捗を監視するフック。
+ *
+ * 使い方:
+ *   const { loaded, total, percentage } = useAssetProgress();
+ */
+import { useState, useEffect } from 'react';
+import { useAssetContext } from './AssetProvider.js';
+import type { ProgressEvent } from '@static3d/types';
+
+export interface ProgressState {
+  /** ダウンロード済みバイト数 */
+  loaded: number;
+  /** 合計バイト数（manifest の size から算出） */
+  total: number;
+  /** 進捗率 0–100 */
+  percentage: number;
+  /** 完了済みアセット数 */
+  completedCount: number;
+  /** 全アセット数 */
+  totalCount: number;
+  /** 現在処理中のアセットキー（未開始時は null） */
+  currentAsset: string | null;
+}
+
+const INITIAL: ProgressState = {
+  loaded: 0,
+  total: 0,
+  percentage: 0,
+  completedCount: 0,
+  totalCount: 0,
+  currentAsset: null,
+};
+
+export function useAssetProgress(): ProgressState {
+  const { progress } = useAssetContext();
+  const [state, setState] = useState<ProgressState>(INITIAL);
+
+  useEffect(() => {
+    if (!progress) return;
+
+    const { loaded, total, asset, completedCount, totalCount } =
+      progress as ProgressEvent;
+
+    setState({
+      loaded,
+      total,
+      percentage: total > 0 ? Math.min(100, (loaded / total) * 100) : 0,
+      completedCount,
+      totalCount,
+      currentAsset: asset ?? null,
+    });
+  }, [progress]);
+
+  return state;
+}

--- a/packages/display/src/scene/Overlay.tsx
+++ b/packages/display/src/scene/Overlay.tsx
@@ -1,0 +1,145 @@
+/**
+ * Overlay.tsx
+ *
+ * 3D 空間上の指定座標に HTML コンテンツをオーバーレイするコンポーネント。
+ * @react-three/drei の Html コンポーネントをラップする。
+ *
+ * 使い方:
+ *   <Overlay position={[0, 2, 0]} anchor="bottom-center">
+ *     <h1>ケーキ屋へようこそ</h1>
+ *   </Overlay>
+ *
+ * ## ESM / peer dep 対応について
+ *
+ * @react-three/drei は optional peer dep。
+ * ESM 環境では require() は動作しないため、動的 import() で
+ * drei.Html をロードする。
+ *
+ * - drei が利用可能 → drei Html コンポーネントで 3D 空間内にレンダリング
+ * - drei が利用不可 → absolute 配置の div にフォールバック
+ *
+ * NOTE: drei.Html は R3F Canvas の内側で使う必要がある。
+ *       Canvas 外で Overlay を使う場合は常に div フォールバックになる。
+ */
+import React, { useState, useEffect } from 'react';
+import type { OverlayProps, OverlayAnchor, Vec3 } from '@static3d/types';
+
+// ────────────────────────────────────────────────────────────────────────────
+// アンカー → CSS transform 変換
+// ────────────────────────────────────────────────────────────────────────────
+
+function anchorToTransform(anchor: OverlayAnchor): string {
+  switch (anchor) {
+    case 'top-left':
+      return 'translate(0%, 0%)';
+    case 'top-center':
+      return 'translate(-50%, 0%)';
+    case 'top-right':
+      return 'translate(-100%, 0%)';
+    case 'bottom-left':
+      return 'translate(0%, -100%)';
+    case 'bottom-center':
+      return 'translate(-50%, -100%)';
+    case 'bottom-right':
+      return 'translate(-100%, -100%)';
+    case 'center':
+    default:
+      return 'translate(-50%, -50%)';
+  }
+}
+
+// ────────────────────────────────────────────────────────────────────────────
+// drei.Html の型（peer dep の型を直接 import せず自前で定義）
+// ────────────────────────────────────────────────────────────────────────────
+
+type DreiHtmlProps = {
+  position?: Vec3;
+  occlude?: boolean;
+  distanceFactor?: number;
+  /** 3D transform モード（position/rotation/scale が 3D 変換に対応） */
+  transform?: boolean;
+  style?: React.CSSProperties;
+  children?: React.ReactNode;
+};
+
+type DreiHtmlComponent = React.ComponentType<DreiHtmlProps>;
+
+// ────────────────────────────────────────────────────────────────────────────
+// モジュールキャッシュ
+// ────────────────────────────────────────────────────────────────────────────
+
+let cachedHtml: DreiHtmlComponent | false | null = null; // null=未ロード, false=利用不可
+
+async function loadHtml(): Promise<DreiHtmlComponent | false> {
+  if (cachedHtml !== null) return cachedHtml;
+
+  try {
+    const drei = await import('@react-three/drei');
+    cachedHtml = drei.Html as unknown as DreiHtmlComponent;
+    return cachedHtml;
+  } catch {
+    cachedHtml = false;
+    return false;
+  }
+}
+
+// ────────────────────────────────────────────────────────────────────────────
+// Overlay
+// ────────────────────────────────────────────────────────────────────────────
+
+export function Overlay({
+  position,
+  anchor = 'bottom-center',
+  occlude = false,
+  distanceFactor,
+  children,
+}: OverlayProps): React.JSX.Element {
+  // null = ロード中, false = 利用不可, DreiHtmlComponent = ready
+  const [Html, setHtml] = useState<DreiHtmlComponent | false | null>(
+    cachedHtml // すでにキャッシュがあれば初期値として使う
+  );
+
+  useEffect(() => {
+    if (cachedHtml !== null) {
+      setHtml(cachedHtml);
+      return;
+    }
+    loadHtml().then(setHtml);
+  }, []);
+
+  const cssTransform = anchorToTransform(anchor);
+
+  // drei.Html が利用可能かつロード済み
+  if (Html) {
+    return (
+      <Html
+        position={position}
+        occlude={occlude}
+        distanceFactor={distanceFactor}
+        transform
+        style={{ transform: cssTransform, pointerEvents: 'auto' }}
+      >
+        {children as React.ReactNode}
+      </Html>
+    );
+  }
+
+  // Fallback: absolute 配置の div
+  // (ロード中 Html===null の間も同じフォールバックを表示)
+  return (
+    <div
+      data-overlay-position={position.join(',')}
+      data-overlay-anchor={anchor}
+      style={{
+        position: 'absolute',
+        left: '50%',
+        top: '50%',
+        transform: `translate(-50%, -50%) ${cssTransform}`,
+        pointerEvents: 'auto',
+        zIndex: 10,
+      }}
+    >
+      {children as React.ReactNode}
+    </div>
+  );
+}

--- a/packages/display/src/scene/Room.tsx
+++ b/packages/display/src/scene/Room.tsx
@@ -1,0 +1,103 @@
+/**
+ * Room.tsx
+ *
+ * URL ルートとカメラ位置を紐付けるコンポーネント。
+ * マウント時または camera props の変更時にカメラ遷移を開始する。
+ *
+ * 使い方:
+ *   <Room camera={{ position: [0,5,10], target: [0,0,0], fov: 60 }}
+ *         transition={{ duration: 1.5, easing: 'easeInOutCubic' }}>
+ *     ...
+ *   </Room>
+ */
+import React, {
+  createContext,
+  useContext,
+  useEffect,
+  useRef,
+  useState,
+} from 'react';
+import { CameraEngine } from './engine/CameraEngine.js';
+import type { RoomProps, CameraState, TransitionConfig } from '@static3d/types';
+
+// ────────────────────────────────────────────────────────────────────────────
+// Context
+// ────────────────────────────────────────────────────────────────────────────
+
+export interface RoomContextValue {
+  engine: CameraEngine;
+  currentCamera: CameraState;
+  transitionTo: (target: CameraState, config?: TransitionConfig) => void;
+}
+
+const RoomContext = createContext<RoomContextValue | null>(null);
+
+export function useRoom(): RoomContextValue {
+  const ctx = useContext(RoomContext);
+  if (!ctx) {
+    throw new Error('[static3d] useRoom must be used inside <Room>');
+  }
+  return ctx;
+}
+
+// ────────────────────────────────────────────────────────────────────────────
+// Room
+// ────────────────────────────────────────────────────────────────────────────
+
+export function Room({
+  camera,
+  transition,
+  children,
+}: RoomProps): React.JSX.Element {
+  const engineRef = useRef<CameraEngine | null>(null);
+
+  if (!engineRef.current) {
+    engineRef.current = new CameraEngine(camera);
+  }
+
+  const [currentCamera, setCurrentCamera] = useState<CameraState>(camera);
+
+  const transitionTo = (target: CameraState, config?: TransitionConfig): void => {
+    engineRef.current!.transitionTo(target, config);
+    setCurrentCamera(target);
+  };
+
+  // camera props が変わったら遷移を開始
+  useEffect(() => {
+    engineRef.current!.transitionTo(camera, transition);
+    setCurrentCamera(camera);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [
+    camera.position.join(','),
+    camera.target.join(','),
+    camera.fov,
+  ]);
+
+  // R3F useFrame からエンジンを動かす（r3f が利用可能な場合のみ）
+  useEffect(() => {
+    let animFrameId: number;
+    let lastTime = performance.now();
+
+    const tick = (now: number): void => {
+      const delta = (now - lastTime) / 1000;
+      lastTime = now;
+      engineRef.current!.tick(delta);
+      animFrameId = requestAnimationFrame(tick);
+    };
+
+    animFrameId = requestAnimationFrame(tick);
+    return () => cancelAnimationFrame(animFrameId);
+  }, []);
+
+  const value: RoomContextValue = {
+    engine: engineRef.current,
+    currentCamera,
+    transitionTo,
+  };
+
+  return (
+    <RoomContext.Provider value={value}>
+      {children as React.ReactNode}
+    </RoomContext.Provider>
+  );
+}

--- a/packages/display/src/scene/Spot.tsx
+++ b/packages/display/src/scene/Spot.tsx
@@ -1,0 +1,122 @@
+/**
+ * Spot.tsx
+ *
+ * クリック・ホバー可能な 3D オブジェクトのラッパーコンポーネント。
+ * highlight（outline / glow / scale / color / none）と
+ * オプショナルな tooltip を提供する。
+ *
+ * 使い方:
+ *   <Spot to="/products" highlight="outline" tooltip="商品を見る">
+ *     <mesh><boxGeometry /><meshStandardMaterial /></mesh>
+ *   </Spot>
+ */
+import React, { useState, useCallback } from 'react';
+import type { SpotProps } from '@static3d/types';
+
+// ────────────────────────────────────────────────────────────────────────────
+// ハイライト実装（スケールで代替。outline/glow は drei Selection で実装可能）
+// ────────────────────────────────────────────────────────────────────────────
+
+function getHoverScale(highlight: SpotProps['highlight']): number {
+  switch (highlight) {
+    case 'scale':
+      return 1.08;
+    case 'outline':
+    case 'glow':
+    case 'color':
+      return 1.02; // わずかなスケールアップ
+    case 'none':
+    default:
+      return 1.0;
+  }
+}
+
+// ────────────────────────────────────────────────────────────────────────────
+// Spot
+// ────────────────────────────────────────────────────────────────────────────
+
+export function Spot({
+  to,
+  highlight = 'outline',
+  tooltip,
+  onClick,
+  onHover,
+  disabled = false,
+  children,
+}: SpotProps): React.JSX.Element {
+  const [hovered, setHovered] = useState(false);
+
+  const handleClick = useCallback((): void => {
+    if (disabled) return;
+    onClick?.();
+    if (to) {
+      // react-router-dom の useNavigate が使えない場合は hash fallback
+      // 利用側は onClick で navigate() を呼ぶことを推奨
+      window.location.hash = to;
+    }
+  }, [disabled, onClick, to]);
+
+  const handlePointerEnter = useCallback((): void => {
+    if (disabled) return;
+    setHovered(true);
+    onHover?.(true);
+  }, [disabled, onHover]);
+
+  const handlePointerLeave = useCallback((): void => {
+    setHovered(false);
+    onHover?.(false);
+  }, [onHover]);
+
+  const scale = hovered && !disabled ? getHoverScale(highlight) : 1.0;
+  const cursor = disabled ? 'default' : 'pointer';
+
+  return (
+    <div
+      data-spot-highlight={highlight}
+      data-spot-to={to}
+      style={{
+        display: 'contents',
+        transform: `scale(${scale})`,
+        cursor,
+        outline: hovered && highlight === 'outline' && !disabled
+          ? '2px solid #00aaff'
+          : undefined,
+        filter: hovered && highlight === 'glow' && !disabled
+          ? 'drop-shadow(0 0 8px #00aaff)'
+          : undefined,
+        transition: 'transform 0.15s ease, filter 0.15s ease',
+      }}
+      role="button"
+      tabIndex={disabled ? -1 : 0}
+      aria-label={tooltip}
+      onClick={handleClick}
+      onMouseEnter={handlePointerEnter}
+      onMouseLeave={handlePointerLeave}
+      onKeyDown={(e) => {
+        if (e.key === 'Enter' || e.key === ' ') handleClick();
+      }}
+    >
+      {children as React.ReactNode}
+      {tooltip && hovered && !disabled && (
+        <div
+          style={{
+            position: 'absolute',
+            bottom: '100%',
+            left: '50%',
+            transform: 'translateX(-50%)',
+            background: 'rgba(0,0,0,0.75)',
+            color: '#fff',
+            padding: '4px 8px',
+            borderRadius: 4,
+            fontSize: 12,
+            whiteSpace: 'nowrap',
+            pointerEvents: 'none',
+            zIndex: 1000,
+          }}
+        >
+          {tooltip}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/packages/display/src/scene/Stage.tsx
+++ b/packages/display/src/scene/Stage.tsx
@@ -1,0 +1,147 @@
+/**
+ * Stage.tsx
+ *
+ * 3D シーンのルートコンテナ。
+ * @react-three/fiber の Canvas + 環境設定をラップする。
+ *
+ * 使い方:
+ *   <Stage environment="warehouse" ambientIntensity={0.5}>
+ *     ...
+ *   </Stage>
+ *
+ * ## ESM / peer dep 対応について
+ *
+ * @react-three/fiber と @react-three/drei は optional peer dep。
+ * ESM 環境では require() は動作しないため、動的 import() を使い
+ * useEffect でモジュールをロードする。
+ *
+ * - R3F が利用可能 → Canvas + ambientLight + Environment でレンダリング
+ * - R3F が利用不可 → <div> フォールバック（ローダーのみ使う場合）
+ */
+import React, { Suspense, useState, useEffect } from 'react';
+import type { StageProps } from '@static3d/types';
+import type { CanvasProps } from '@react-three/fiber';
+
+// ────────────────────────────────────────────────────────────────────────────
+// 動的 import で取得する peer dep の型
+// ────────────────────────────────────────────────────────────────────────────
+
+type R3FCanvas = React.ComponentType<CanvasProps>;
+type DreiEnvironment = React.ComponentType<{
+  preset?: string;
+  background?: boolean;
+}>;
+
+interface PeerModules {
+  Canvas: R3FCanvas;
+  Environment: DreiEnvironment | null;
+}
+
+// ────────────────────────────────────────────────────────────────────────────
+// モジュールキャッシュ（コンポーネントの再マウントで再 import しない）
+// ────────────────────────────────────────────────────────────────────────────
+
+let cachedModules: PeerModules | null = null;
+let loadPromise: Promise<PeerModules | null> | null = null;
+
+async function loadPeerModules(): Promise<PeerModules | null> {
+  if (cachedModules) return cachedModules;
+  if (loadPromise) return loadPromise;
+
+  loadPromise = (async () => {
+    try {
+      const [r3f, drei] = await Promise.allSettled([
+        import('@react-three/fiber'),
+        import('@react-three/drei'),
+      ]);
+
+      if (r3f.status === 'rejected') {
+        // R3F がなければ Canvas を提供できない → null
+        loadPromise = null;
+        return null;
+      }
+
+      const Canvas = (r3f.value as typeof import('@react-three/fiber'))
+        .Canvas as unknown as R3FCanvas;
+
+      const Environment =
+        drei.status === 'fulfilled'
+          ? ((drei.value as typeof import('@react-three/drei'))
+              .Environment as unknown as DreiEnvironment)
+          : null;
+
+      cachedModules = { Canvas, Environment };
+      return cachedModules;
+    } catch {
+      loadPromise = null;
+      return null;
+    }
+  })();
+
+  return loadPromise;
+}
+
+// ────────────────────────────────────────────────────────────────────────────
+// Stage
+// ────────────────────────────────────────────────────────────────────────────
+
+type StageImplProps = StageProps & { canvasProps?: Omit<CanvasProps, 'children'> };
+
+export function Stage({
+  environment = 'warehouse',
+  ambientIntensity = 0.5,
+  background = '#000000',
+  shadows = true,
+  className,
+  style,
+  children,
+}: StageImplProps): React.JSX.Element {
+  // null = loading, false = unavailable, PeerModules = ready
+  const [mods, setMods] = useState<PeerModules | null | false>(
+    cachedModules ?? null
+  );
+
+  useEffect(() => {
+    if (cachedModules) {
+      setMods(cachedModules);
+      return;
+    }
+    loadPeerModules().then((m) => setMods(m ?? false));
+  }, []);
+
+  // peer dep ロード中または利用不可 → フォールバック
+  if (!mods) {
+    return (
+      <div
+        className={className}
+        style={{
+          width: '100%',
+          height: '100%',
+          background,
+          ...(style as React.CSSProperties),
+        }}
+      >
+        {/* mods===null はローディング中, false は peer dep 未インストール */}
+        {children as React.ReactNode}
+      </div>
+    );
+  }
+
+  const { Canvas, Environment } = mods;
+
+  return (
+    <Canvas
+      shadows={shadows}
+      className={className}
+      style={{ background, ...(style as React.CSSProperties) }}
+    >
+      <ambientLight intensity={ambientIntensity} />
+      <Suspense fallback={null}>
+        {Environment && (
+          <Environment preset={environment} background={false} />
+        )}
+        {children as React.ReactNode}
+      </Suspense>
+    </Canvas>
+  );
+}

--- a/packages/display/src/scene/engine/CameraEngine.ts
+++ b/packages/display/src/scene/engine/CameraEngine.ts
@@ -1,0 +1,141 @@
+/**
+ * CameraEngine.ts
+ *
+ * カメラ遷移アニメーションエンジン。
+ * @react-three/fiber の useFrame を使い、CameraState 間を
+ * イージング関数でスムーズに補間する。
+ *
+ * ブラウザ専用。Node.js モジュールは使わない。
+ */
+import type { CameraState, TransitionConfig, Vec3 } from '@static3d/types';
+
+// ────────────────────────────────────────────────────────────────────────────
+// イージング関数
+// ────────────────────────────────────────────────────────────────────────────
+
+type EasingFn = (t: number) => number;
+
+const easings: Record<NonNullable<TransitionConfig['easing']>, EasingFn> = {
+  linear: (t) => t,
+  easeInCubic: (t) => t * t * t,
+  easeOutCubic: (t) => 1 - Math.pow(1 - t, 3),
+  easeInOutCubic: (t) =>
+    t < 0.5 ? 4 * t * t * t : 1 - Math.pow(-2 * t + 2, 3) / 2,
+  easeInQuart: (t) => t * t * t * t,
+  easeOutQuart: (t) => 1 - Math.pow(1 - t, 4),
+  easeInOutQuart: (t) =>
+    t < 0.5 ? 8 * t * t * t * t : 1 - Math.pow(-2 * t + 2, 4) / 2,
+};
+
+// ────────────────────────────────────────────────────────────────────────────
+// ユーティリティ
+// ────────────────────────────────────────────────────────────────────────────
+
+function lerp(a: number, b: number, t: number): number {
+  return a + (b - a) * t;
+}
+
+function lerpVec3(a: Vec3, b: Vec3, t: number): Vec3 {
+  return [lerp(a[0], b[0], t), lerp(a[1], b[1], t), lerp(a[2], b[2], t)];
+}
+
+// ────────────────────────────────────────────────────────────────────────────
+// CameraEngine
+// ────────────────────────────────────────────────────────────────────────────
+
+export interface CameraEngineState {
+  /** 現在のカメラ位置 */
+  position: Vec3;
+  /** 現在の注視点 */
+  target: Vec3;
+  /** 現在の FOV */
+  fov: number;
+  /** 遷移中か否か */
+  isTransitioning: boolean;
+}
+
+export class CameraEngine {
+  private current: CameraEngineState;
+  private from: CameraState | null = null;
+  private to: CameraState | null = null;
+  private progress = 0; // 0–1
+  private duration = 1.0; // 秒
+  private easingFn: EasingFn = easings.easeInOutCubic;
+
+  constructor(initial: CameraState) {
+    this.current = {
+      position: initial.position,
+      target: initial.target,
+      fov: initial.fov ?? 60,
+      isTransitioning: false,
+    };
+  }
+
+  /**
+   * 指定した CameraState へ遷移を開始する。
+   * すでに遷移中の場合は現在の補間状態から続けて遷移する。
+   */
+  transitionTo(target: CameraState, config?: TransitionConfig): void {
+    this.from = {
+      position: [...this.current.position] as Vec3,
+      target: [...this.current.target] as Vec3,
+      fov: this.current.fov,
+    };
+    this.to = target;
+    this.progress = 0;
+    this.duration = config?.duration ?? 1.0;
+    this.easingFn = easings[config?.easing ?? 'easeInOutCubic'];
+    this.current.isTransitioning = true;
+  }
+
+  /**
+   * useFrame のコールバックから毎フレーム呼ぶ。
+   * @param delta 前フレームからの経過秒数
+   * @returns 現在のカメラ状態
+   */
+  tick(delta: number): CameraEngineState {
+    if (!this.current.isTransitioning || !this.from || !this.to) {
+      return this.current;
+    }
+
+    this.progress = Math.min(1, this.progress + delta / this.duration);
+    const t = this.easingFn(this.progress);
+
+    this.current.position = lerpVec3(this.from.position, this.to.position, t);
+    this.current.target = lerpVec3(
+      this.from.target,
+      this.to.target,
+      t
+    );
+    this.current.fov = lerp(
+      this.from.fov ?? 60,
+      this.to.fov ?? 60,
+      t
+    );
+
+    if (this.progress >= 1) {
+      this.current.isTransitioning = false;
+      this.from = null;
+    }
+
+    return { ...this.current };
+  }
+
+  /** 現在の状態を即座に設定（アニメーションなし） */
+  set(state: CameraState): void {
+    this.current = {
+      position: state.position,
+      target: state.target,
+      fov: state.fov ?? 60,
+      isTransitioning: false,
+    };
+    this.from = null;
+    this.to = null;
+    this.progress = 0;
+  }
+
+  /** 現在のカメラ状態を返す */
+  getState(): CameraEngineState {
+    return { ...this.current };
+  }
+}

--- a/packages/display/src/tests/AssetLoader.test.ts
+++ b/packages/display/src/tests/AssetLoader.test.ts
@@ -1,0 +1,227 @@
+/**
+ * AssetLoader.test.ts
+ *
+ * AssetLoader の単体テスト。
+ * fetch を vi.stubGlobal でモックし、実ネットワークを使わない。
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { AssetLoader } from '../loader/AssetLoader.js';
+import type { DeployManifest } from '@static3d/types';
+
+// ────────────────────────────────────────────────────────────────────────────
+// テスト用マニフェスト
+// ────────────────────────────────────────────────────────────────────────────
+
+const MANIFEST_URL = 'https://pages.example.com/manifest.json';
+
+const MOCK_MANIFEST: DeployManifest = {
+  schemaVersion: 1,
+  version: 'abc1234',
+  buildTime: '2026-01-01T00:00:00.000Z',
+  assets: {
+    'textures/albedo.png': {
+      url: 'https://cdn.example.com/textures/albedo.8cbce19e.png',
+      size: 1024,
+      hash: 'sha256:' + 'a'.repeat(64),
+      contentType: 'image/png',
+    },
+    'models/scene.gltf': {
+      url: 'https://cdn.example.com/models/scene.2073f5d5.gltf',
+      size: 2048,
+      hash: 'sha256:' + 'b'.repeat(64),
+      contentType: 'model/gltf+json',
+      dependencies: ['textures/albedo.png'],
+    },
+  },
+};
+
+// ────────────────────────────────────────────────────────────────────────────
+// fetch モックユーティリティ
+// ────────────────────────────────────────────────────────────────────────────
+
+function makeManifestFetch(manifest: DeployManifest = MOCK_MANIFEST) {
+  return (url: string): Promise<Response> => {
+    if (url === MANIFEST_URL) {
+      return Promise.resolve(
+        new Response(JSON.stringify(manifest), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        })
+      );
+    }
+    // アセット URL → PNG バイナリ相当
+    return Promise.resolve(
+      new Response(new Uint8Array(8).buffer, {
+        status: 200,
+        headers: { 'Content-Type': 'application/octet-stream' },
+      })
+    );
+  };
+}
+
+// ────────────────────────────────────────────────────────────────────────────
+// tests
+// ────────────────────────────────────────────────────────────────────────────
+
+describe('AssetLoader', () => {
+  beforeEach(() => {
+    vi.stubGlobal('fetch', vi.fn(makeManifestFetch()));
+    // crypto.subtle.digest をスタブ（Node 環境では動作するが念のため）
+    vi.stubGlobal('crypto', {
+      subtle: {
+        digest: vi.fn().mockResolvedValue(
+          new Uint8Array(32).fill(0xaa).buffer
+        ),
+      },
+    });
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  // ── init / manifest 取得 ───────────────────────────────────────────────
+
+  it('init() fetches and caches the manifest', async () => {
+    const loader = new AssetLoader(MANIFEST_URL);
+    await loader.init();
+
+    expect(fetch).toHaveBeenCalledWith(
+      MANIFEST_URL,
+      expect.objectContaining({ cache: 'no-store' })
+    );
+    expect(loader.getManifest()).toMatchObject({
+      schemaVersion: 1,
+      version: 'abc1234',
+    });
+  });
+
+  it('init() does not fetch twice (caches manifest)', async () => {
+    const loader = new AssetLoader(MANIFEST_URL);
+    await loader.init();
+    await loader.init();
+
+    expect(fetch).toHaveBeenCalledTimes(1);
+  });
+
+  // ── load ──────────────────────────────────────────────────────────────
+
+  it('load() returns ArrayBuffer for binary asset', async () => {
+    const loader = new AssetLoader(MANIFEST_URL, { integrity: false });
+    const result = await loader.load('textures/albedo.png', {
+      responseType: 'arraybuffer',
+    });
+
+    expect(result).toBeInstanceOf(ArrayBuffer);
+  });
+
+  it('load() returns Blob for blob responseType', async () => {
+    const loader = new AssetLoader(MANIFEST_URL, { integrity: false });
+    const result = await loader.load('textures/albedo.png', {
+      responseType: 'blob',
+    });
+
+    expect(result).toBeInstanceOf(Blob);
+  });
+
+  it('load() throws LoadError for unknown key', async () => {
+    const loader = new AssetLoader(MANIFEST_URL, { integrity: false });
+    await expect(loader.load('nonexistent/file.png')).rejects.toMatchObject({
+      type: 'not-found',
+      key: 'nonexistent/file.png',
+    });
+  });
+
+  // ── loadAll ───────────────────────────────────────────────────────────
+
+  it('loadAll() returns a Map with all assets', async () => {
+    const loader = new AssetLoader(MANIFEST_URL, { integrity: false });
+    const result = await loader.loadAll();
+
+    expect(result.size).toBe(2);
+    expect(result.has('textures/albedo.png')).toBe(true);
+    expect(result.has('models/scene.gltf')).toBe(true);
+  });
+
+  it('loadAll({ keys }) returns only requested keys', async () => {
+    const loader = new AssetLoader(MANIFEST_URL, { integrity: false });
+    const result = await loader.loadAll({ keys: ['textures/albedo.png'] });
+
+    expect(result.size).toBe(1);
+    expect(result.has('textures/albedo.png')).toBe(true);
+  });
+
+  // ── progress ──────────────────────────────────────────────────────────
+
+  it('onProgress callback is called for each asset', async () => {
+    const loader = new AssetLoader(MANIFEST_URL, { integrity: false });
+    const events: string[] = [];
+
+    loader.onProgress((e) => {
+      events.push(e.asset);
+    });
+
+    await loader.loadAll();
+    expect(events.length).toBeGreaterThan(0);
+    expect(events.some((k) => k.includes('albedo') || k.includes('scene'))).toBe(true);
+  });
+
+  // ── onError callback ──────────────────────────────────────────────────
+
+  it('onError callback is called on network failure', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn((url: string) => {
+        if (url === MANIFEST_URL) {
+          return Promise.resolve(
+            new Response(JSON.stringify(MOCK_MANIFEST), { status: 200 })
+          );
+        }
+        return Promise.resolve(new Response('Not Found', { status: 404 }));
+      })
+    );
+
+    const loader = new AssetLoader(MANIFEST_URL, {
+      integrity: false,
+      retryCount: 0,
+    });
+    const errors: string[] = [];
+    loader.onError((e) => errors.push(e.type));
+
+    try {
+      await loader.load('textures/albedo.png');
+    } catch {
+      // expected
+    }
+
+    expect(errors).toContain('network');
+  });
+
+  // ── cancel ────────────────────────────────────────────────────────────
+
+  it('cancel() prevents further loads', async () => {
+    const loader = new AssetLoader(MANIFEST_URL, { integrity: false });
+    loader.cancel();
+
+    await expect(loader.load('textures/albedo.png')).rejects.toMatchObject({
+      type: 'abort',
+    });
+  });
+
+  // ── manifest fetch failure ────────────────────────────────────────────
+
+  it('init() throws LoadError on manifest 500', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(() =>
+        Promise.resolve(new Response('Server Error', { status: 500 }))
+      )
+    );
+
+    const loader = new AssetLoader(MANIFEST_URL);
+    await expect(loader.init()).rejects.toMatchObject({
+      type: 'network',
+      key: '__manifest__',
+    });
+  });
+});

--- a/packages/display/src/tests/CameraEngine.test.ts
+++ b/packages/display/src/tests/CameraEngine.test.ts
@@ -1,0 +1,100 @@
+/**
+ * CameraEngine.test.ts
+ *
+ * CameraEngine のユニットテスト。
+ * DOM / R3F に依存しない純粋なロジックテスト。
+ */
+import { describe, it, expect } from 'vitest';
+import { CameraEngine } from '../scene/engine/CameraEngine.js';
+import type { CameraState } from '@static3d/types';
+
+const START: CameraState = {
+  position: [0, 5, 10],
+  target: [0, 0, 0],
+  fov: 60,
+};
+
+const END: CameraState = {
+  position: [10, 0, 0],
+  target: [5, 0, 0],
+  fov: 45,
+};
+
+describe('CameraEngine', () => {
+  it('initialises with the given CameraState', () => {
+    const engine = new CameraEngine(START);
+    const state = engine.getState();
+    expect(state.position).toEqual([0, 5, 10]);
+    expect(state.target).toEqual([0, 0, 0]);
+    expect(state.fov).toBe(60);
+    expect(state.isTransitioning).toBe(false);
+  });
+
+  it('set() changes state immediately without animation', () => {
+    const engine = new CameraEngine(START);
+    engine.set(END);
+    const state = engine.getState();
+    expect(state.position).toEqual([10, 0, 0]);
+    expect(state.isTransitioning).toBe(false);
+  });
+
+  it('transitionTo() starts a transition', () => {
+    const engine = new CameraEngine(START);
+    engine.transitionTo(END, { duration: 1.0 });
+    const state = engine.getState();
+    expect(state.isTransitioning).toBe(true);
+  });
+
+  it('tick() advances the transition by delta', () => {
+    const engine = new CameraEngine(START);
+    engine.transitionTo(END, { duration: 1.0, easing: 'linear' });
+
+    // 0.5 秒後 → t = 0.5
+    engine.tick(0.5);
+    const mid = engine.getState();
+
+    expect(mid.position[0]).toBeCloseTo(5, 1); // lerp(0, 10, 0.5)
+    expect(mid.isTransitioning).toBe(true);
+  });
+
+  it('tick() completes transition when progress >= 1', () => {
+    const engine = new CameraEngine(START);
+    engine.transitionTo(END, { duration: 1.0, easing: 'linear' });
+
+    engine.tick(1.0); // exactly 1 second
+    const final = engine.getState();
+
+    expect(final.position).toEqual([10, 0, 0]);
+    expect(final.target).toEqual([5, 0, 0]);
+    expect(final.fov).toBeCloseTo(45);
+    expect(final.isTransitioning).toBe(false);
+  });
+
+  it('tick() beyond 1.0 clamps to final state', () => {
+    const engine = new CameraEngine(START);
+    engine.transitionTo(END, { duration: 1.0, easing: 'linear' });
+
+    engine.tick(2.0); // overshoot
+    const state = engine.getState();
+    expect(state.position).toEqual([10, 0, 0]);
+    expect(state.isTransitioning).toBe(false);
+  });
+
+  it('supports all easing names without throwing', () => {
+    const easings: Array<NonNullable<import('@static3d/types').TransitionConfig['easing']>> = [
+      'linear',
+      'easeInCubic',
+      'easeOutCubic',
+      'easeInOutCubic',
+      'easeInQuart',
+      'easeOutQuart',
+      'easeInOutQuart',
+    ];
+
+    for (const easing of easings) {
+      const engine = new CameraEngine(START);
+      engine.transitionTo(END, { duration: 1.0, easing });
+      expect(() => engine.tick(0.5)).not.toThrow();
+    }
+  });
+});

--- a/packages/display/src/tests/hooks.test.ts
+++ b/packages/display/src/tests/hooks.test.ts
@@ -1,0 +1,152 @@
+/**
+ * hooks.test.tsx
+ *
+ * useAssetProgress フックのテスト。
+ * AssetProvider + useAssetProgress の統合テスト。
+ *
+ * @testing-library/react は devDep に含まれていないため、
+ * React の renderHook 代わりに簡易テストで検証する。
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { AssetLoader } from '../loader/AssetLoader.js';
+import type { DeployManifest, ProgressEvent } from '@static3d/types';
+
+// ────────────────────────────────────────────────────────────────────────────
+// テスト用マニフェスト
+// ────────────────────────────────────────────────────────────────────────────
+
+const MANIFEST_URL = 'https://pages.example.com/manifest.json';
+
+const MOCK_MANIFEST: DeployManifest = {
+  schemaVersion: 1,
+  version: 'hook-test',
+  buildTime: '2026-01-01T00:00:00.000Z',
+  assets: {
+    'textures/albedo.png': {
+      url: 'https://cdn.example.com/textures/albedo.8cbce19e.png',
+      size: 512,
+      hash: 'sha256:' + 'c'.repeat(64),
+      contentType: 'image/png',
+    },
+    'models/scene.gltf': {
+      url: 'https://cdn.example.com/models/scene.2073f5d5.gltf',
+      size: 1024,
+      hash: 'sha256:' + 'd'.repeat(64),
+      contentType: 'model/gltf+json',
+    },
+  },
+};
+
+function makeManifestFetch() {
+  return (url: string): Promise<Response> => {
+    if (url === MANIFEST_URL) {
+      return Promise.resolve(
+        new Response(JSON.stringify(MOCK_MANIFEST), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        })
+      );
+    }
+    return Promise.resolve(
+      new Response(new Uint8Array(8).buffer, {
+        status: 200,
+        headers: { 'Content-Type': 'application/octet-stream' },
+      })
+    );
+  };
+}
+
+// ────────────────────────────────────────────────────────────────────────────
+// AssetLoader 経由のフック統合テスト（React hook 部分は AssetLoader のイベントで確認）
+// ────────────────────────────────────────────────────────────────────────────
+
+describe('AssetLoader progress integration', () => {
+  beforeEach(() => {
+    vi.stubGlobal('fetch', vi.fn(makeManifestFetch()));
+    vi.stubGlobal('crypto', {
+      subtle: {
+        digest: vi.fn().mockResolvedValue(new Uint8Array(32).fill(0xbb).buffer),
+      },
+    });
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('progress events report correct totals and percentages', async () => {
+    const loader = new AssetLoader(MANIFEST_URL, { integrity: false });
+    const events: ProgressEvent[] = [];
+    loader.onProgress((e) => events.push({ ...e }));
+
+    await loader.loadAll();
+
+    expect(events.length).toBe(2); // 2 assets
+    const last = events[events.length - 1];
+    expect(last.completedCount).toBe(2);
+    expect(last.totalCount).toBe(2);
+    expect(last.loaded).toBeGreaterThan(0);
+    expect(last.total).toBeGreaterThan(0);
+  });
+
+  it('totalCount equals number of assets in manifest', async () => {
+    const loader = new AssetLoader(MANIFEST_URL, { integrity: false });
+    let totalCount = 0;
+    loader.onProgress((e) => {
+      totalCount = e.totalCount;
+    });
+
+    await loader.loadAll();
+    expect(totalCount).toBe(Object.keys(MOCK_MANIFEST.assets).length);
+  });
+
+  it('loaded bytes increase monotonically', async () => {
+    const loader = new AssetLoader(MANIFEST_URL, { integrity: false });
+    const loadedHistory: number[] = [];
+    loader.onProgress((e) => loadedHistory.push(e.loaded));
+
+    await loader.loadAll();
+
+    for (let i = 1; i < loadedHistory.length; i++) {
+      expect(loadedHistory[i]).toBeGreaterThanOrEqual(loadedHistory[i - 1]);
+    }
+  });
+
+  it('loadAll with keys filter emits only matching progress events', async () => {
+    const loader = new AssetLoader(MANIFEST_URL, { integrity: false });
+    const events: ProgressEvent[] = [];
+    loader.onProgress((e) => events.push({ ...e }));
+
+    await loader.loadAll({ keys: ['textures/albedo.png'] });
+
+    expect(events.length).toBe(1);
+    expect(events[0].asset).toContain('albedo');
+  });
+});
+
+// ────────────────────────────────────────────────────────────────────────────
+// ProgressState 計算ロジック（hook の計算を直接テスト）
+// ────────────────────────────────────────────────────────────────────────────
+
+describe('ProgressState calculation', () => {
+  it('percentage is 0 when total is 0', () => {
+    const loaded = 0;
+    const total = 0;
+    const percentage = total > 0 ? Math.min(100, (loaded / total) * 100) : 0;
+    expect(percentage).toBe(0);
+  });
+
+  it('percentage is capped at 100', () => {
+    const loaded = 200;
+    const total = 100;
+    const percentage = Math.min(100, (loaded / total) * 100);
+    expect(percentage).toBe(100);
+  });
+
+  it('percentage is correctly calculated', () => {
+    const loaded = 512;
+    const total = 1536;
+    const percentage = total > 0 ? Math.min(100, (loaded / total) * 100) : 0;
+    expect(percentage).toBeCloseTo(33.33, 1);
+  });
+});

--- a/packages/display/tsconfig.json
+++ b/packages/display/tsconfig.json
@@ -1,0 +1,24 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "lib": ["ES2022", "DOM", "DOM.Iterable"],
+    "jsx": "react-jsx",
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "outDir": "dist",
+    "rootDir": "src",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "composite": true,
+    "noUnusedLocals": false,
+    "noUnusedParameters": false
+  },
+  "references": [
+    { "path": "../types" }
+  ],
+  "include": ["src"]
+}

--- a/packages/display/vitest.config.ts
+++ b/packages/display/vitest.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    environment: 'happy-dom',
+    globals: true,
+  },
+});

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -9,3 +9,24 @@ export type {
   DraftConfig,
   Static3dConfig,
 } from './config.js';
+
+export type {
+  LoaderOptions,
+  LoadOptions,
+  LoadAllOptions,
+  ProgressEvent,
+  LoadError,
+  AssetResult,
+} from './loader.js';
+
+export type {
+  Vec3,
+  CameraState,
+  TransitionConfig,
+  StageProps,
+  RoomProps,
+  SpotHighlight,
+  SpotProps,
+  OverlayAnchor,
+  OverlayProps,
+} from './scene.js';

--- a/packages/types/src/loader.ts
+++ b/packages/types/src/loader.ts
@@ -1,0 +1,84 @@
+/**
+ * @static3d/types — loader types
+ *
+ * ブラウザ専用ローダー (@static3d/display) で使う型定義。
+ * Node.js 依存なし。
+ */
+
+/** ローダー全体のオプション */
+export interface LoaderOptions {
+  /** 同時ダウンロード数（デフォルト: 4） */
+  concurrency?: number;
+  /** リトライ回数（デフォルト: 3） */
+  retryCount?: number;
+  /** 初回リトライ待機 ms（指数バックオフ、デフォルト: 1000） */
+  retryDelay?: number;
+  /** タイムアウト ms（デフォルト: 30000） */
+  timeout?: number;
+  /**
+   * SRI ハッシュ検証を有効化（デフォルト: true）
+   * manifest の hash フィールド（"sha256:<hex64>"）で SubresourceIntegrity 検証を行う
+   */
+  integrity?: boolean;
+}
+
+/** 単一アセット取得オプション */
+export interface LoadOptions {
+  /**
+   * レスポンス形式（デフォルト: contentType から自動判定）
+   * - 'blob': Blob で返す
+   * - 'arraybuffer': ArrayBuffer で返す
+   * - 'json': JSON.parse した値を返す
+   */
+  responseType?: 'blob' | 'arraybuffer' | 'json';
+  /** 優先度（デフォルト: 'normal'） */
+  priority?: 'high' | 'normal' | 'low';
+  /** キャンセル用 AbortSignal */
+  signal?: AbortSignal;
+}
+
+/** loadAll のオプション */
+export interface LoadAllOptions extends LoadOptions {
+  /** 取得するアセットキーのフィルタ（指定なし = 全て） */
+  keys?: string[];
+}
+
+/** 進捗イベント */
+export interface ProgressEvent {
+  /** ダウンロード済みバイト数 */
+  loaded: number;
+  /** 合計バイト数（manifest の size から算出） */
+  total: number;
+  /** 現在ダウンロード中のアセットキー */
+  asset: string;
+  /** 完了済みアセット数 */
+  completedCount: number;
+  /** 全アセット数 */
+  totalCount: number;
+}
+
+/** ロードエラー */
+export interface LoadError {
+  /** エラー種別 */
+  type: 'network' | 'timeout' | 'integrity' | 'not-found' | 'abort' | 'unknown';
+  /** アセットキー */
+  key: string;
+  /** CDN URL */
+  url: string;
+  /** 元の Error */
+  cause?: Error;
+  /** HTTP ステータスコード（network エラー時） */
+  statusCode?: number;
+}
+
+/** useAsset の戻り値 */
+export interface AssetResult<T = Blob> {
+  /** 取得済みアセットデータ */
+  data: T;
+  /** アセットキー */
+  key: string;
+  /** CDN URL */
+  url: string;
+  /** コンテンツタイプ */
+  contentType: string;
+}

--- a/packages/types/src/scene.ts
+++ b/packages/types/src/scene.ts
@@ -1,0 +1,107 @@
+/**
+ * @static3d/types — scene types
+ *
+ * React/R3F ベースのシーンコンポーネント (@static3d/display) で使う型定義。
+ * Node.js 依存なし。React・Three.js の型は optional peer dep のため
+ * ここでは直接 import せず、プリミティブ型でモデリングする。
+ */
+
+/** 3D 座標 [x, y, z] */
+export type Vec3 = [number, number, number];
+
+/** カメラ状態 */
+export interface CameraState {
+  /** カメラ位置 */
+  position: Vec3;
+  /** 注視点 */
+  target: Vec3;
+  /** 視野角（度） */
+  fov?: number;
+}
+
+/** カメラ遷移設定 */
+export interface TransitionConfig {
+  /** 遷移時間（秒、デフォルト: 1.0） */
+  duration?: number;
+  /** イージング関数名（デフォルト: 'easeInOutCubic'） */
+  easing?:
+    | 'linear'
+    | 'easeInCubic'
+    | 'easeOutCubic'
+    | 'easeInOutCubic'
+    | 'easeInQuart'
+    | 'easeOutQuart'
+    | 'easeInOutQuart';
+}
+
+/** Stage コンポーネントの Props */
+export interface StageProps {
+  /**
+   * @react-three/drei の Environment の preset
+   * (例: 'warehouse', 'city', 'sunset', 'night', ...)
+   */
+  environment?: string;
+  /** アンビエントライトの強度（デフォルト: 0.5） */
+  ambientIntensity?: number;
+  /** Canvas の背景色（CSS 色文字列、デフォルト: '#000000'） */
+  background?: string;
+  /** shadows を有効化（デフォルト: true） */
+  shadows?: boolean;
+  /** Canvas の className */
+  className?: string;
+  /** canvas style */
+  style?: Record<string, string | number>;
+  children?: unknown;
+}
+
+/** Room コンポーネントの Props */
+export interface RoomProps {
+  /** カメラ位置・注視点・FOV */
+  camera: CameraState;
+  /** カメラ遷移設定 */
+  transition?: TransitionConfig;
+  children?: unknown;
+}
+
+/** Spot のハイライト表現 */
+export type SpotHighlight = 'outline' | 'glow' | 'scale' | 'color' | 'none';
+
+/** Spot コンポーネントの Props */
+export interface SpotProps {
+  /** クリック時の遷移先パス（react-router の to と同じ形式） */
+  to?: string;
+  /** ホバー・フォーカス時のハイライト（デフォルト: 'outline'） */
+  highlight?: SpotHighlight;
+  /** ツールチップテキスト */
+  tooltip?: string;
+  /** クリックハンドラ */
+  onClick?: () => void;
+  /** ホバーハンドラ */
+  onHover?: (hovered: boolean) => void;
+  /** 無効化 */
+  disabled?: boolean;
+  children?: unknown;
+}
+
+/** Overlay のアンカー位置 */
+export type OverlayAnchor =
+  | 'center'
+  | 'top-left'
+  | 'top-center'
+  | 'top-right'
+  | 'bottom-left'
+  | 'bottom-center'
+  | 'bottom-right';
+
+/** Overlay コンポーネントの Props */
+export interface OverlayProps {
+  /** 3D 空間上の位置 */
+  position: Vec3;
+  /** HTML のアンカー基準（デフォルト: 'bottom-center'） */
+  anchor?: OverlayAnchor;
+  /** オクルージョンを有効化（デフォルト: false） */
+  occlude?: boolean;
+  /** 距離スケーリングを無効化（デフォルト: false） */
+  distanceFactor?: number;
+  children?: unknown;
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -40,7 +40,44 @@ importers:
         version: 6.4.1(@types/node@22.19.11)
       vitest:
         specifier: ^2.0.0
-        version: 2.1.9(@types/node@22.19.11)
+        version: 2.1.9(@types/node@22.19.11)(happy-dom@20.6.3)
+
+  packages/display:
+    dependencies:
+      '@static3d/types':
+        specifier: workspace:*
+        version: link:../types
+    devDependencies:
+      '@react-three/drei':
+        specifier: ^9.0.0
+        version: 9.122.0(@react-three/fiber@9.5.0(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(three@0.172.0))(@types/react@19.2.14)(@types/three@0.172.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(three@0.172.0)(use-sync-external-store@1.6.0(react@19.2.4))
+      '@react-three/fiber':
+        specifier: ^9.0.0
+        version: 9.5.0(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(three@0.172.0)
+      '@types/react':
+        specifier: ^19.0.0
+        version: 19.2.14
+      '@types/three':
+        specifier: ^0.172.0
+        version: 0.172.0
+      happy-dom:
+        specifier: ^20.6.3
+        version: 20.6.3
+      react:
+        specifier: ^19.0.0
+        version: 19.2.4
+      react-dom:
+        specifier: ^19.0.0
+        version: 19.2.4(react@19.2.4)
+      three:
+        specifier: ^0.172.0
+        version: 0.172.0
+      typescript:
+        specifier: ^5.7.0
+        version: 5.9.3
+      vitest:
+        specifier: ^2.0.0
+        version: 2.1.9(@types/node@22.19.11)(happy-dom@20.6.3)
 
   packages/types:
     devDependencies:
@@ -218,6 +255,10 @@ packages:
   '@aws/lambda-invoke-store@0.2.3':
     resolution: {integrity: sha512-oLvsaPMTBejkkmHhjf09xTgk71mOqyr/409NKhRIL08If7AhVfUsJhVsx386uJaqNd42v9kWamQ9lFbkoC2dYw==}
     engines: {node: '>=18.0.0'}
+
+  '@babel/runtime@7.28.6':
+    resolution: {integrity: sha512-05WQkdpL9COIMz4LjTxGpPNCdlpyimKppYNoJ5Di5EUObifl8t4tuLuUBBZEpoLYOmfvIWrsp9fCl0HoPRVTdA==}
+    engines: {node: '>=6.9.0'}
 
   '@esbuild/aix-ppc64@0.21.5':
     resolution: {integrity: sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ==}
@@ -519,6 +560,78 @@ packages:
 
   '@jridgewell/sourcemap-codec@1.5.5':
     resolution: {integrity: sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==}
+
+  '@mediapipe/tasks-vision@0.10.17':
+    resolution: {integrity: sha512-CZWV/q6TTe8ta61cZXjfnnHsfWIdFhms03M9T7Cnd5y2mdpylJM0rF1qRq+wsQVRMLz1OYPVEBU9ph2Bx8cxrg==}
+
+  '@monogrid/gainmap-js@3.4.0':
+    resolution: {integrity: sha512-2Z0FATFHaoYJ8b+Y4y4Hgfn3FRFwuU5zRrk+9dFWp4uGAdHGqVEdP7HP+gLA3X469KXHmfupJaUbKo1b/aDKIg==}
+    peerDependencies:
+      three: '>= 0.159.0'
+
+  '@react-spring/animated@9.7.5':
+    resolution: {integrity: sha512-Tqrwz7pIlsSDITzxoLS3n/v/YCUHQdOIKtOJf4yL6kYVSDTSmVK1LI1Q3M/uu2Sx4X3pIWF3xLUhlsA6SPNTNg==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0
+
+  '@react-spring/core@9.7.5':
+    resolution: {integrity: sha512-rmEqcxRcu7dWh7MnCcMXLvrf6/SDlSokLaLTxiPlAYi11nN3B5oiCUAblO72o+9z/87j2uzxa2Inm8UbLjXA+w==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0
+
+  '@react-spring/rafz@9.7.5':
+    resolution: {integrity: sha512-5ZenDQMC48wjUzPAm1EtwQ5Ot3bLIAwwqP2w2owG5KoNdNHpEJV263nGhCeKKmuA3vG2zLLOdu3or6kuDjA6Aw==}
+
+  '@react-spring/shared@9.7.5':
+    resolution: {integrity: sha512-wdtoJrhUeeyD/PP/zo+np2s1Z820Ohr/BbuVYv+3dVLW7WctoiN7std8rISoYoHpUXtbkpesSKuPIw/6U1w1Pw==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0
+
+  '@react-spring/three@9.7.5':
+    resolution: {integrity: sha512-RxIsCoQfUqOS3POmhVHa1wdWS0wyHAUway73uRLp3GAL5U2iYVNdnzQsep6M2NZ994BlW8TcKuMtQHUqOsy6WA==}
+    peerDependencies:
+      '@react-three/fiber': '>=6.0'
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0
+      three: '>=0.126'
+
+  '@react-spring/types@9.7.5':
+    resolution: {integrity: sha512-HVj7LrZ4ReHWBimBvu2SKND3cDVUPWKLqRTmWe/fNY6o1owGOX0cAHbdPDTMelgBlVbrTKrre6lFkhqGZErK/g==}
+
+  '@react-three/drei@9.122.0':
+    resolution: {integrity: sha512-SEO/F/rBCTjlLez7WAlpys+iGe9hty4rNgjZvgkQeXFSiwqD4Hbk/wNHMAbdd8vprO2Aj81mihv4dF5bC7D0CA==}
+    peerDependencies:
+      '@react-three/fiber': ^8
+      react: ^18
+      react-dom: ^18
+      three: '>=0.137'
+    peerDependenciesMeta:
+      react-dom:
+        optional: true
+
+  '@react-three/fiber@9.5.0':
+    resolution: {integrity: sha512-FiUzfYW4wB1+PpmsE47UM+mCads7j2+giRBltfwH7SNhah95rqJs3ltEs9V3pP8rYdS0QlNne+9Aj8dS/SiaIA==}
+    peerDependencies:
+      expo: '>=43.0'
+      expo-asset: '>=8.4'
+      expo-file-system: '>=11.0'
+      expo-gl: '>=11.0'
+      react: '>=19 <19.3'
+      react-dom: '>=19 <19.3'
+      react-native: '>=0.78'
+      three: '>=0.156'
+    peerDependenciesMeta:
+      expo:
+        optional: true
+      expo-asset:
+        optional: true
+      expo-file-system:
+        optional: true
+      expo-gl:
+        optional: true
+      react-dom:
+        optional: true
+      react-native:
+        optional: true
 
   '@rollup/rollup-android-arm-eabi@4.57.1':
     resolution: {integrity: sha512-A6ehUVSiSaaliTxai040ZpZ2zTevHYbvu/lDoeAteHI8QnaosIzm4qwtezfRg1jOYaUmnzLX1AOD6Z+UJjtifg==}
@@ -861,6 +974,12 @@ packages:
     resolution: {integrity: sha512-4aUIteuyxtBUhVdiQqcDhKFitwfd9hqoSDYY2KRXiWtgoWJ9Bmise+KfEPDiVHWeJepvF8xJO9/9+WDIciMFFw==}
     engines: {node: '>=18.0.0'}
 
+  '@tweenjs/tween.js@23.1.3':
+    resolution: {integrity: sha512-vJmvvwFxYuGnF2axRtPYocag6Clbb5YS7kLL+SO/TeVFzHqDIWrNKYtcsPMibjDx9O+bu+psAy9NKfWklassUA==}
+
+  '@types/draco3d@1.4.10':
+    resolution: {integrity: sha512-AX22jp8Y7wwaBgAixaSvkoG4M/+PlAcm3Qs4OW8yT9DM4xUpWKeFhLueTAyZF39pviAdcDdeJoACapiAceqNcw==}
+
   '@types/estree@1.0.8':
     resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
 
@@ -869,6 +988,40 @@ packages:
 
   '@types/node@22.19.11':
     resolution: {integrity: sha512-BH7YwL6rA93ReqeQS1c4bsPpcfOmJasG+Fkr6Y59q83f9M1WcBRHR2vM+P9eOisYRcN3ujQoiZY8uk5W+1WL8w==}
+
+  '@types/offscreencanvas@2019.7.3':
+    resolution: {integrity: sha512-ieXiYmgSRXUDeOntE1InxjWyvEelZGP63M+cGuquuRLuIKKT1osnkXjxev9B7d1nXSug5vpunx+gNlbVxMlC9A==}
+
+  '@types/react-reconciler@0.28.9':
+    resolution: {integrity: sha512-HHM3nxyUZ3zAylX8ZEyrDNd2XZOnQ0D5XfunJF5FLQnZbHHYq4UWvW1QfelQNXv1ICNkwYhfxjwfnqivYB6bFg==}
+    peerDependencies:
+      '@types/react': '*'
+
+  '@types/react@19.2.14':
+    resolution: {integrity: sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==}
+
+  '@types/stats.js@0.17.4':
+    resolution: {integrity: sha512-jIBvWWShCvlBqBNIZt0KAshWpvSjhkwkEu4ZUcASoAvhmrgAUI2t1dXrjSL4xXVLB4FznPrIsX3nKXFl/Dt4vA==}
+
+  '@types/three@0.172.0':
+    resolution: {integrity: sha512-LrUtP3FEG26Zg5WiF0nbg8VoXiKokBLTcqM2iLvM9vzcfEiYmmBAPGdBgV0OYx9fvWlY3R/3ERTZcD9X5sc0NA==}
+
+  '@types/webxr@0.5.24':
+    resolution: {integrity: sha512-h8fgEd/DpoS9CBrjEQXR+dIDraopAEfu4wYVNY2tEPwk60stPWhvZMf4Foo5FakuQ7HFZoa8WceaWFervK2Ovg==}
+
+  '@types/whatwg-mimetype@3.0.2':
+    resolution: {integrity: sha512-c2AKvDT8ToxLIOUlN51gTiHXflsfIFisS4pO7pDPoKouJCESkhZnEy623gwP9laCy5lnLDAw1vAzu2vM2YLOrA==}
+
+  '@types/ws@8.18.1':
+    resolution: {integrity: sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==}
+
+  '@use-gesture/core@10.3.1':
+    resolution: {integrity: sha512-WcINiDt8WjqBdUXye25anHiNxPc0VOrlT8F6LLkU6cycrOGUDyY/yyFmsg3k8i5OLvv25llc0QC45GhR/C8llw==}
+
+  '@use-gesture/react@10.3.1':
+    resolution: {integrity: sha512-Yy19y6O2GJq8f7CHf7L0nxL8bf4PZCPaVOCgJrusOeFHY1LvHgYXnmnXg6N5iwAnbgbZCDjo60SiM6IPJi9C5g==}
+    peerDependencies:
+      react: '>= 16.8.0'
 
   '@vitest/expect@2.1.9':
     resolution: {integrity: sha512-UJCIkTBenHeKT1TTlKMJWy1laZewsRIzYighyYiJKZreqtdxSos/S1t+ktRMQWu2CKqaarrkeszJx1cgC5tGZw==}
@@ -899,6 +1052,9 @@ packages:
   '@vitest/utils@2.1.9':
     resolution: {integrity: sha512-v0psaMSkNJ3A2NMrUEHFRzJtDPFn+/VWZ5WxImB21T9fjucJRmS7xCS3ppEnARb9y11OAzaD+P2Ps+b+BGX5iQ==}
 
+  '@webgpu/types@0.1.69':
+    resolution: {integrity: sha512-RPmm6kgRbI8e98zSD3RVACvnuktIja5+yLgDAkTmxLr90BEwdTXRQWNLF3ETTTyH/8mKhznZuN5AveXYFEsMGQ==}
+
   assertion-error@2.0.1:
     resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
     engines: {node: '>=12'}
@@ -910,6 +1066,9 @@ packages:
   base64-js@1.5.1:
     resolution: {integrity: sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==}
 
+  bidi-js@1.0.3:
+    resolution: {integrity: sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==}
+
   bowser@2.14.1:
     resolution: {integrity: sha512-tzPjzCxygAKWFOJP011oxFHs57HzIhOEracIgAePE4pqB3LikALKnSzUyU4MGs9/iCEUuHlAJTjTc5M+u7YEGg==}
 
@@ -920,9 +1079,17 @@ packages:
   buffer@5.6.0:
     resolution: {integrity: sha512-/gDYp/UtU0eA1ys8bOs9J6a+E/KWIY+DZ+Q2WESNUA0jFRsJOc0SNUO6xJ5SGA1xueg3NL65W6s+NY5l9cunuw==}
 
+  buffer@6.0.3:
+    resolution: {integrity: sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==}
+
   cac@6.7.14:
     resolution: {integrity: sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==}
     engines: {node: '>=8'}
+
+  camera-controls@2.10.1:
+    resolution: {integrity: sha512-KnaKdcvkBJ1Irbrzl8XD6WtZltkRjp869Jx8c0ujs9K+9WD+1D7ryBsCiVqJYUqt6i/HR5FxT7RLASieUD+Q5w==}
+    peerDependencies:
+      three: '>=0.126.1'
 
   chai@5.3.3:
     resolution: {integrity: sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==}
@@ -932,9 +1099,17 @@ packages:
     resolution: {integrity: sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==}
     engines: {node: '>= 16'}
 
+  cross-env@7.0.3:
+    resolution: {integrity: sha512-+/HKd6EgcQCJGh2PSjZuUitQBQynKor4wrFbRg4DtAgS1aWO+gU52xpH7M9ScGgXSYmAVS9bIJ8EzuaGw0oNAw==}
+    engines: {node: '>=10.14', npm: '>=6', yarn: '>=1'}
+    hasBin: true
+
   cross-spawn@7.0.6:
     resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
     engines: {node: '>= 8'}
+
+  csstype@3.2.3:
+    resolution: {integrity: sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==}
 
   debug@4.4.3:
     resolution: {integrity: sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==}
@@ -948,6 +1123,16 @@ packages:
   deep-eql@5.0.2:
     resolution: {integrity: sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==}
     engines: {node: '>=6'}
+
+  detect-gpu@5.0.70:
+    resolution: {integrity: sha512-bqerEP1Ese6nt3rFkwPnGbsUF9a4q+gMmpTVVOEzoCyeCc+y7/RvJnQZJx1JwhgQI5Ntg0Kgat8Uu7XpBqnz1w==}
+
+  draco3d@1.5.7:
+    resolution: {integrity: sha512-m6WCKt/erDXcw+70IJXnG7M3awwQPAsZvJGX5zY7beBqpELw6RDGkYVU0W43AFxye4pDZ5i2Lbyc/NNGqwjUVQ==}
+
+  entities@7.0.1:
+    resolution: {integrity: sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==}
+    engines: {node: '>=0.12'}
 
   es-module-lexer@1.7.0:
     resolution: {integrity: sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==}
@@ -986,6 +1171,12 @@ packages:
       picomatch:
         optional: true
 
+  fflate@0.6.10:
+    resolution: {integrity: sha512-IQrh3lEPM93wVCEczc9SaAOvkmcoQn/G8Bo1e8ZPlY3X3bnAxWaBdvTdvM1hP62iZp0BXWDy4vTAy4fF0+Dlpg==}
+
+  fflate@0.8.2:
+    resolution: {integrity: sha512-cPJU47OaAoCbg0pBvzsgpTPhmhqI5eJjh/JIu8tPj5q+T7iLvW/JAYUqmE7KOB4R1ZyEhzBaIQpQpardBF5z8A==}
+
   foreground-child@3.3.1:
     resolution: {integrity: sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==}
     engines: {node: '>=14'}
@@ -1001,18 +1192,49 @@ packages:
     deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
     hasBin: true
 
+  glsl-noise@0.0.0:
+    resolution: {integrity: sha512-b/ZCF6amfAUb7dJM/MxRs7AetQEahYzJ8PtgfrmEdtw6uyGOr+ZSGtgjFm6mfsBkxJ4d2W7kg+Nlqzqvn3Bc0w==}
+
+  happy-dom@20.6.3:
+    resolution: {integrity: sha512-QAMY7d228dHs8gb9NG4SJ3OxQo4r+NGN8pOXGZ3SGfQf/XYuuYubrtZ25QVY2WoUQdskhRXSXb4R4mcRk+hV1w==}
+    engines: {node: '>=20.0.0'}
+
+  hls.js@1.6.15:
+    resolution: {integrity: sha512-E3a5VwgXimGHwpRGV+WxRTKeSp2DW5DI5MWv34ulL3t5UNmyJWCQ1KmLEHbYzcfThfXG8amBL+fCYPneGHC4VA==}
+
   ieee754@1.2.1:
     resolution: {integrity: sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==}
+
+  immediate@3.0.6:
+    resolution: {integrity: sha512-XXOFtyqDjNDAQxVfYxuF7g9Il/IbWmmlQg2MYKOH8ExIT1qg6xc4zyS3HaEEATgs1btfzxq15ciUiY7gjSXRGQ==}
 
   inherits@2.0.4:
     resolution: {integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==}
 
+  is-promise@2.2.2:
+    resolution: {integrity: sha512-+lP4/6lKUBfQjZ2pdxThZvLUAafmZb8OAxFb8XXtiQmS35INgr85hdOGoEs124ez1FCnZJt6jau/T+alh58QFQ==}
+
   isexe@2.0.0:
     resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
+
+  its-fine@2.0.0:
+    resolution: {integrity: sha512-KLViCmWx94zOvpLwSlsx6yOCeMhZYaxrJV87Po5k/FoZzcPSahvK5qJ7fYhS61sZi5ikmh2S3Hz55A2l3U69ng==}
+    peerDependencies:
+      react: ^19.0.0
 
   jackspeak@4.2.3:
     resolution: {integrity: sha512-ykkVRwrYvFm1nb2AJfKKYPr0emF6IiXDYUaFx4Zn9ZuIH7MrzEZ3sD5RlqGXNRpHtvUHJyOnCEFxOlNDtGo7wg==}
     engines: {node: 20 || >=22}
+
+  js-tokens@4.0.0:
+    resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
+
+  lie@3.3.0:
+    resolution: {integrity: sha512-UaiMJzeWRlEujzAuw5LokY1L5ecNQYZKfmyZ9L7wDHb/p5etKaxXhohBcrw0EYby+G/NA52vRSN4N39dxHAIwQ==}
+
+  loose-envify@1.4.0:
+    resolution: {integrity: sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==}
+    hasBin: true
 
   loupe@3.2.1:
     resolution: {integrity: sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==}
@@ -1021,8 +1243,22 @@ packages:
     resolution: {integrity: sha512-ESL2CrkS/2wTPfuend7Zhkzo2u0daGJ/A2VucJOgQ/C48S/zB8MMeMHSGKYpXhIjbPxfuezITkaBH1wqv00DDQ==}
     engines: {node: 20 || >=22}
 
+  maath@0.10.8:
+    resolution: {integrity: sha512-tRvbDF0Pgqz+9XUa4jjfgAQ8/aPKmQdWXilFu2tMy4GWj4NOsx99HlULO4IeREfbO3a0sA145DZYyvXPkybm0g==}
+    peerDependencies:
+      '@types/three': '>=0.134.0'
+      three: '>=0.134.0'
+
   magic-string@0.30.21:
     resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
+
+  meshline@3.3.1:
+    resolution: {integrity: sha512-/TQj+JdZkeSUOl5Mk2J7eLcYTLiQm2IDzmlSvYm7ov15anEcDJ92GHqqazxTSreeNgfnYu24kiEvvv0WlbCdFQ==}
+    peerDependencies:
+      three: '>=0.137'
+
+  meshoptimizer@0.18.1:
+    resolution: {integrity: sha512-ZhoIoL7TNV4s5B6+rx5mC//fw8/POGyNxS/DZyCJeiZ12ScLfVwRE/GfsxwiTkMYYD5DmK2/JXnEVXqL4rF+Sw==}
 
   mime-db@1.52.0:
     resolution: {integrity: sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==}
@@ -1047,6 +1283,10 @@ packages:
     resolution: {integrity: sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
+
+  object-assign@4.1.1:
+    resolution: {integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==}
+    engines: {node: '>=0.10.0'}
 
   package-json-from-dist@1.0.1:
     resolution: {integrity: sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==}
@@ -1077,9 +1317,48 @@ packages:
     resolution: {integrity: sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==}
     engines: {node: ^10 || ^12 || >=14}
 
+  potpack@1.0.2:
+    resolution: {integrity: sha512-choctRBIV9EMT9WGAZHn3V7t0Z2pMQyl0EZE6pFc/6ml3ssw7Dlf/oAOvFwjm1HVsqfQN8GfeFyJ+d8tRzqueQ==}
+
+  promise-worker-transferable@1.0.4:
+    resolution: {integrity: sha512-bN+0ehEnrXfxV2ZQvU2PetO0n4gqBD4ulq3MI1WOPLgr7/Mg9yRQkX5+0v1vagr74ZTsl7XtzlaYDo2EuCeYJw==}
+
+  prop-types@15.8.1:
+    resolution: {integrity: sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==}
+
+  react-composer@5.0.3:
+    resolution: {integrity: sha512-1uWd07EME6XZvMfapwZmc7NgCZqDemcvicRi3wMJzXsQLvZ3L7fTHVyPy1bZdnWXM4iPjYuNE+uJ41MLKeTtnA==}
+    peerDependencies:
+      react: ^15.0.0 || ^16.0.0 || ^17.0.0 || ^18.0.0
+
+  react-dom@19.2.4:
+    resolution: {integrity: sha512-AXJdLo8kgMbimY95O2aKQqsz2iWi9jMgKJhRBAxECE4IFxfcazB2LmzloIoibJI3C12IlY20+KFaLv+71bUJeQ==}
+    peerDependencies:
+      react: ^19.2.4
+
+  react-is@16.13.1:
+    resolution: {integrity: sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==}
+
+  react-use-measure@2.1.7:
+    resolution: {integrity: sha512-KrvcAo13I/60HpwGO5jpW7E9DfusKyLPLvuHlUyP5zqnmAPhNc6qTRjUQrdTADl0lpPpDVU2/Gg51UlOGHXbdg==}
+    peerDependencies:
+      react: '>=16.13'
+      react-dom: '>=16.13'
+    peerDependenciesMeta:
+      react-dom:
+        optional: true
+
+  react@19.2.4:
+    resolution: {integrity: sha512-9nfp2hYpCwOjAN+8TZFGhtWEwgvWHXqESH8qT89AT/lWklpLON22Lc8pEtnpsZz7VmawabSU0gCjnj8aC0euHQ==}
+    engines: {node: '>=0.10.0'}
+
   readable-stream@3.6.2:
     resolution: {integrity: sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==}
     engines: {node: '>= 6'}
+
+  require-from-string@2.0.2:
+    resolution: {integrity: sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==}
+    engines: {node: '>=0.10.0'}
 
   rollup@4.57.1:
     resolution: {integrity: sha512-oQL6lgK3e2QZeQ7gcgIkS2YZPg5slw37hYufJ3edKlfQSGGm8ICoxswK15ntSzF/a8+h7ekRy7k7oWc3BQ7y8A==}
@@ -1088,6 +1367,9 @@ packages:
 
   safe-buffer@5.2.1:
     resolution: {integrity: sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==}
+
+  scheduler@0.27.0:
+    resolution: {integrity: sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==}
 
   shebang-command@2.0.0:
     resolution: {integrity: sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==}
@@ -1111,6 +1393,15 @@ packages:
   stackback@0.0.2:
     resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
 
+  stats-gl@2.4.2:
+    resolution: {integrity: sha512-g5O9B0hm9CvnM36+v7SFl39T7hmAlv541tU81ME8YeSb3i1CIP5/QdDeSB3A0la0bKNHpxpwxOVRo2wFTYEosQ==}
+    peerDependencies:
+      '@types/three': '*'
+      three: '*'
+
+  stats.js@0.17.0:
+    resolution: {integrity: sha512-hNKz8phvYLPEcRkeG1rsGmV5ChMjKDAWU7/OJJdDErPBNChQXxCo3WZurGpnWc6gZhAzEPFad1aVgyOANH1sMw==}
+
   std-env@3.10.0:
     resolution: {integrity: sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==}
 
@@ -1122,6 +1413,25 @@ packages:
 
   strnum@2.1.2:
     resolution: {integrity: sha512-l63NF9y/cLROq/yqKXSLtcMeeyOfnSQlfMSlzFt/K73oIaD8DGaQWd7Z34X9GPiKqP5rbSh84Hl4bOlLcjiSrQ==}
+
+  suspend-react@0.1.3:
+    resolution: {integrity: sha512-aqldKgX9aZqpoDp3e8/BZ8Dm7x1pJl+qI3ZKxDN0i/IQTWUwBx/ManmlVJ3wowqbno6c2bmiIfs+Um6LbsjJyQ==}
+    peerDependencies:
+      react: '>=17.0'
+
+  three-mesh-bvh@0.7.8:
+    resolution: {integrity: sha512-BGEZTOIC14U0XIRw3tO4jY7IjP7n7v24nv9JXS1CyeVRWOCkcOMhRnmENUjuV39gktAw4Ofhr0OvIAiTspQrrw==}
+    deprecated: Deprecated due to three.js version incompatibility. Please use v0.8.0, instead.
+    peerDependencies:
+      three: '>= 0.151.0'
+
+  three-stdlib@2.36.1:
+    resolution: {integrity: sha512-XyGQrFmNQ5O/IoKm556ftwKsBg11TIb301MB5dWNicziQBEs2g3gtOYIf7pFiLa0zI2gUwhtCjv9fmjnxKZ1Cg==}
+    peerDependencies:
+      three: '>=0.128.0'
+
+  three@0.172.0:
+    resolution: {integrity: sha512-6HMgMlzU97MsV7D/tY8Va38b83kz8YJX+BefKjspMNAv0Vx6dxMogHOrnRl/sbMIs3BPUKijPqDqJ/+UwJbIow==}
 
   tinybench@2.9.0:
     resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
@@ -1145,8 +1455,24 @@ packages:
     resolution: {integrity: sha512-n1cw8k1k0x4pgA2+9XrOkFydTerNcJ1zWCO5Nn9scWHTD+5tp8dghT2x1uduQePZTZgd3Tupf+x9BxJjeJi77Q==}
     engines: {node: '>=14.0.0'}
 
+  troika-three-text@0.52.4:
+    resolution: {integrity: sha512-V50EwcYGruV5rUZ9F4aNsrytGdKcXKALjEtQXIOBfhVoZU9VAqZNIoGQ3TMiooVqFAbR1w15T+f+8gkzoFzawg==}
+    peerDependencies:
+      three: '>=0.125.0'
+
+  troika-three-utils@0.52.4:
+    resolution: {integrity: sha512-NORAStSVa/BDiG52Mfudk4j1FG4jC4ILutB3foPnfGbOeIs9+G5vZLa0pnmnaftZUGm4UwSoqEpWdqvC7zms3A==}
+    peerDependencies:
+      three: '>=0.125.0'
+
+  troika-worker-utils@0.52.0:
+    resolution: {integrity: sha512-W1CpvTHykaPH5brv5VHLfQo9D1OYuo0cSBEUQFFT/nBUzM8iD6Lq2/tgG/f1OelbAS1WtaTPQzE5uM49egnngw==}
+
   tslib@2.8.1:
     resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
+
+  tunnel-rat@0.1.2:
+    resolution: {integrity: sha512-lR5VHmkPhzdhrM092lI2nACsLO4QubF0/yoOhzX7c+wIpbN1GjHNzCc91QlpxBi+cnx8vVJ+Ur6vL5cEoQPFpQ==}
 
   typescript@5.9.3:
     resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
@@ -1156,8 +1482,17 @@ packages:
   undici-types@6.21.0:
     resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
 
+  use-sync-external-store@1.6.0:
+    resolution: {integrity: sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+
   util-deprecate@1.0.2:
     resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
+
+  utility-types@3.11.0:
+    resolution: {integrity: sha512-6Z7Ma2aVEWisaL6TvBCy7P8rm2LQoPv6dJ7ecIaIixHcwfbJ0x7mWdbcwlIM5IGQxPZSFYeqRCqlOOeKoJYMkw==}
+    engines: {node: '>= 4'}
 
   vite-node@2.1.9:
     resolution: {integrity: sha512-AM9aQ/IPrW/6ENLQg3AGY4K1N2TGZdR5e4gu/MmmR2xR3Ll1+dib+nook92g4TV3PXVyeyxdWwtaCAiUL0hMxA==}
@@ -1260,6 +1595,16 @@ packages:
       jsdom:
         optional: true
 
+  webgl-constants@1.1.1:
+    resolution: {integrity: sha512-LkBXKjU5r9vAW7Gcu3T5u+5cvSvh5WwINdr0C+9jpzVB41cjQAP5ePArDtk/WHYdVj0GefCgM73BA7FlIiNtdg==}
+
+  webgl-sdf-generator@1.1.1:
+    resolution: {integrity: sha512-9Z0JcMTFxeE+b2x1LJTdnaT8rT8aEp7MVxkNwoycNmJWwPdzoXzMh0BjJSh/AEFP+KPYZUli814h8bJZFIZ2jA==}
+
+  whatwg-mimetype@3.0.0:
+    resolution: {integrity: sha512-nt+N2dzIutVRxARx1nghPKGv1xHikU7HKdfafKkLNLindmPU/ch3U31NOCGGA/dmPcmb1VlofO0vnKAcsm0o/Q==}
+    engines: {node: '>=12'}
+
   which@2.0.2:
     resolution: {integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==}
     engines: {node: '>= 8'}
@@ -1269,6 +1614,51 @@ packages:
     resolution: {integrity: sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==}
     engines: {node: '>=8'}
     hasBin: true
+
+  ws@8.19.0:
+    resolution: {integrity: sha512-blAT2mjOEIi0ZzruJfIhb3nps74PRWTCz1IjglWEEpQl5XS/UNama6u2/rjFkDDouqr4L67ry+1aGIALViWjDg==}
+    engines: {node: '>=10.0.0'}
+    peerDependencies:
+      bufferutil: ^4.0.1
+      utf-8-validate: '>=5.0.2'
+    peerDependenciesMeta:
+      bufferutil:
+        optional: true
+      utf-8-validate:
+        optional: true
+
+  zustand@4.5.7:
+    resolution: {integrity: sha512-CHOUy7mu3lbD6o6LJLfllpjkzhHXSBlX8B9+qPddUsIfeF5S/UZ5q0kmCsnRqT1UHFQZchNFDDzMbQsuesHWlw==}
+    engines: {node: '>=12.7.0'}
+    peerDependencies:
+      '@types/react': '>=16.8'
+      immer: '>=9.0.6'
+      react: '>=16.8'
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      immer:
+        optional: true
+      react:
+        optional: true
+
+  zustand@5.0.11:
+    resolution: {integrity: sha512-fdZY+dk7zn/vbWNCYmzZULHRrss0jx5pPFiOuMZ/5HJN6Yv3u+1Wswy/4MpZEkEGhtNH+pwxZB8OKgUBPzYAGg==}
+    engines: {node: '>=12.20.0'}
+    peerDependencies:
+      '@types/react': '>=18.0.0'
+      immer: '>=9.0.6'
+      react: '>=18.0.0'
+      use-sync-external-store: '>=1.2.0'
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      immer:
+        optional: true
+      react:
+        optional: true
+      use-sync-external-store:
+        optional: true
 
 snapshots:
 
@@ -1768,6 +2158,8 @@ snapshots:
 
   '@aws/lambda-invoke-store@0.2.3': {}
 
+  '@babel/runtime@7.28.6': {}
+
   '@esbuild/aix-ppc64@0.21.5':
     optional: true
 
@@ -1918,6 +2310,101 @@ snapshots:
   '@isaacs/cliui@9.0.0': {}
 
   '@jridgewell/sourcemap-codec@1.5.5': {}
+
+  '@mediapipe/tasks-vision@0.10.17': {}
+
+  '@monogrid/gainmap-js@3.4.0(three@0.172.0)':
+    dependencies:
+      promise-worker-transferable: 1.0.4
+      three: 0.172.0
+
+  '@react-spring/animated@9.7.5(react@19.2.4)':
+    dependencies:
+      '@react-spring/shared': 9.7.5(react@19.2.4)
+      '@react-spring/types': 9.7.5
+      react: 19.2.4
+
+  '@react-spring/core@9.7.5(react@19.2.4)':
+    dependencies:
+      '@react-spring/animated': 9.7.5(react@19.2.4)
+      '@react-spring/shared': 9.7.5(react@19.2.4)
+      '@react-spring/types': 9.7.5
+      react: 19.2.4
+
+  '@react-spring/rafz@9.7.5': {}
+
+  '@react-spring/shared@9.7.5(react@19.2.4)':
+    dependencies:
+      '@react-spring/rafz': 9.7.5
+      '@react-spring/types': 9.7.5
+      react: 19.2.4
+
+  '@react-spring/three@9.7.5(@react-three/fiber@9.5.0(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(three@0.172.0))(react@19.2.4)(three@0.172.0)':
+    dependencies:
+      '@react-spring/animated': 9.7.5(react@19.2.4)
+      '@react-spring/core': 9.7.5(react@19.2.4)
+      '@react-spring/shared': 9.7.5(react@19.2.4)
+      '@react-spring/types': 9.7.5
+      '@react-three/fiber': 9.5.0(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(three@0.172.0)
+      react: 19.2.4
+      three: 0.172.0
+
+  '@react-spring/types@9.7.5': {}
+
+  '@react-three/drei@9.122.0(@react-three/fiber@9.5.0(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(three@0.172.0))(@types/react@19.2.14)(@types/three@0.172.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(three@0.172.0)(use-sync-external-store@1.6.0(react@19.2.4))':
+    dependencies:
+      '@babel/runtime': 7.28.6
+      '@mediapipe/tasks-vision': 0.10.17
+      '@monogrid/gainmap-js': 3.4.0(three@0.172.0)
+      '@react-spring/three': 9.7.5(@react-three/fiber@9.5.0(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(three@0.172.0))(react@19.2.4)(three@0.172.0)
+      '@react-three/fiber': 9.5.0(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(three@0.172.0)
+      '@use-gesture/react': 10.3.1(react@19.2.4)
+      camera-controls: 2.10.1(three@0.172.0)
+      cross-env: 7.0.3
+      detect-gpu: 5.0.70
+      glsl-noise: 0.0.0
+      hls.js: 1.6.15
+      maath: 0.10.8(@types/three@0.172.0)(three@0.172.0)
+      meshline: 3.3.1(three@0.172.0)
+      react: 19.2.4
+      react-composer: 5.0.3(react@19.2.4)
+      stats-gl: 2.4.2(@types/three@0.172.0)(three@0.172.0)
+      stats.js: 0.17.0
+      suspend-react: 0.1.3(react@19.2.4)
+      three: 0.172.0
+      three-mesh-bvh: 0.7.8(three@0.172.0)
+      three-stdlib: 2.36.1(three@0.172.0)
+      troika-three-text: 0.52.4(three@0.172.0)
+      tunnel-rat: 0.1.2(@types/react@19.2.14)(react@19.2.4)
+      utility-types: 3.11.0
+      zustand: 5.0.11(@types/react@19.2.14)(react@19.2.4)(use-sync-external-store@1.6.0(react@19.2.4))
+    optionalDependencies:
+      react-dom: 19.2.4(react@19.2.4)
+    transitivePeerDependencies:
+      - '@types/react'
+      - '@types/three'
+      - immer
+      - use-sync-external-store
+
+  '@react-three/fiber@9.5.0(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(three@0.172.0)':
+    dependencies:
+      '@babel/runtime': 7.28.6
+      '@types/webxr': 0.5.24
+      base64-js: 1.5.1
+      buffer: 6.0.3
+      its-fine: 2.0.0(@types/react@19.2.14)(react@19.2.4)
+      react: 19.2.4
+      react-use-measure: 2.1.7(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      scheduler: 0.27.0
+      suspend-react: 0.1.3(react@19.2.4)
+      three: 0.172.0
+      use-sync-external-store: 1.6.0(react@19.2.4)
+      zustand: 5.0.11(@types/react@19.2.14)(react@19.2.4)(use-sync-external-store@1.6.0(react@19.2.4))
+    optionalDependencies:
+      react-dom: 19.2.4(react@19.2.4)
+    transitivePeerDependencies:
+      - '@types/react'
+      - immer
 
   '@rollup/rollup-android-arm-eabi@4.57.1':
     optional: true
@@ -2332,6 +2819,10 @@ snapshots:
     dependencies:
       tslib: 2.8.1
 
+  '@tweenjs/tween.js@23.1.3': {}
+
+  '@types/draco3d@1.4.10': {}
+
   '@types/estree@1.0.8': {}
 
   '@types/mime-types@2.1.4': {}
@@ -2339,6 +2830,42 @@ snapshots:
   '@types/node@22.19.11':
     dependencies:
       undici-types: 6.21.0
+
+  '@types/offscreencanvas@2019.7.3': {}
+
+  '@types/react-reconciler@0.28.9(@types/react@19.2.14)':
+    dependencies:
+      '@types/react': 19.2.14
+
+  '@types/react@19.2.14':
+    dependencies:
+      csstype: 3.2.3
+
+  '@types/stats.js@0.17.4': {}
+
+  '@types/three@0.172.0':
+    dependencies:
+      '@tweenjs/tween.js': 23.1.3
+      '@types/stats.js': 0.17.4
+      '@types/webxr': 0.5.24
+      '@webgpu/types': 0.1.69
+      fflate: 0.8.2
+      meshoptimizer: 0.18.1
+
+  '@types/webxr@0.5.24': {}
+
+  '@types/whatwg-mimetype@3.0.2': {}
+
+  '@types/ws@8.18.1':
+    dependencies:
+      '@types/node': 22.19.11
+
+  '@use-gesture/core@10.3.1': {}
+
+  '@use-gesture/react@10.3.1(react@19.2.4)':
+    dependencies:
+      '@use-gesture/core': 10.3.1
+      react: 19.2.4
 
   '@vitest/expect@2.1.9':
     dependencies:
@@ -2380,11 +2907,17 @@ snapshots:
       loupe: 3.2.1
       tinyrainbow: 1.2.0
 
+  '@webgpu/types@0.1.69': {}
+
   assertion-error@2.0.1: {}
 
   balanced-match@4.0.3: {}
 
   base64-js@1.5.1: {}
+
+  bidi-js@1.0.3:
+    dependencies:
+      require-from-string: 2.0.2
 
   bowser@2.14.1: {}
 
@@ -2397,7 +2930,16 @@ snapshots:
       base64-js: 1.5.1
       ieee754: 1.2.1
 
+  buffer@6.0.3:
+    dependencies:
+      base64-js: 1.5.1
+      ieee754: 1.2.1
+
   cac@6.7.14: {}
+
+  camera-controls@2.10.1(three@0.172.0):
+    dependencies:
+      three: 0.172.0
 
   chai@5.3.3:
     dependencies:
@@ -2409,17 +2951,31 @@ snapshots:
 
   check-error@2.1.3: {}
 
+  cross-env@7.0.3:
+    dependencies:
+      cross-spawn: 7.0.6
+
   cross-spawn@7.0.6:
     dependencies:
       path-key: 3.1.1
       shebang-command: 2.0.0
       which: 2.0.2
 
+  csstype@3.2.3: {}
+
   debug@4.4.3:
     dependencies:
       ms: 2.1.3
 
   deep-eql@5.0.2: {}
+
+  detect-gpu@5.0.70:
+    dependencies:
+      webgl-constants: 1.1.1
+
+  draco3d@1.5.7: {}
+
+  entities@7.0.1: {}
 
   es-module-lexer@1.7.0: {}
 
@@ -2494,6 +3050,10 @@ snapshots:
     optionalDependencies:
       picomatch: 4.0.3
 
+  fflate@0.6.10: {}
+
+  fflate@0.8.2: {}
+
   foreground-child@3.3.1:
     dependencies:
       cross-spawn: 7.0.6
@@ -2511,23 +3071,71 @@ snapshots:
       package-json-from-dist: 1.0.1
       path-scurry: 2.0.1
 
+  glsl-noise@0.0.0: {}
+
+  happy-dom@20.6.3:
+    dependencies:
+      '@types/node': 22.19.11
+      '@types/whatwg-mimetype': 3.0.2
+      '@types/ws': 8.18.1
+      entities: 7.0.1
+      whatwg-mimetype: 3.0.0
+      ws: 8.19.0
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
+
+  hls.js@1.6.15: {}
+
   ieee754@1.2.1: {}
+
+  immediate@3.0.6: {}
 
   inherits@2.0.4: {}
 
+  is-promise@2.2.2: {}
+
   isexe@2.0.0: {}
+
+  its-fine@2.0.0(@types/react@19.2.14)(react@19.2.4):
+    dependencies:
+      '@types/react-reconciler': 0.28.9(@types/react@19.2.14)
+      react: 19.2.4
+    transitivePeerDependencies:
+      - '@types/react'
 
   jackspeak@4.2.3:
     dependencies:
       '@isaacs/cliui': 9.0.0
 
+  js-tokens@4.0.0: {}
+
+  lie@3.3.0:
+    dependencies:
+      immediate: 3.0.6
+
+  loose-envify@1.4.0:
+    dependencies:
+      js-tokens: 4.0.0
+
   loupe@3.2.1: {}
 
   lru-cache@11.2.6: {}
 
+  maath@0.10.8(@types/three@0.172.0)(three@0.172.0):
+    dependencies:
+      '@types/three': 0.172.0
+      three: 0.172.0
+
   magic-string@0.30.21:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
+
+  meshline@3.3.1(three@0.172.0):
+    dependencies:
+      three: 0.172.0
+
+  meshoptimizer@0.18.1: {}
 
   mime-db@1.52.0: {}
 
@@ -2544,6 +3152,8 @@ snapshots:
   ms@2.1.3: {}
 
   nanoid@3.3.11: {}
+
+  object-assign@4.1.1: {}
 
   package-json-from-dist@1.0.1: {}
 
@@ -2568,11 +3178,46 @@ snapshots:
       picocolors: 1.1.1
       source-map-js: 1.2.1
 
+  potpack@1.0.2: {}
+
+  promise-worker-transferable@1.0.4:
+    dependencies:
+      is-promise: 2.2.2
+      lie: 3.3.0
+
+  prop-types@15.8.1:
+    dependencies:
+      loose-envify: 1.4.0
+      object-assign: 4.1.1
+      react-is: 16.13.1
+
+  react-composer@5.0.3(react@19.2.4):
+    dependencies:
+      prop-types: 15.8.1
+      react: 19.2.4
+
+  react-dom@19.2.4(react@19.2.4):
+    dependencies:
+      react: 19.2.4
+      scheduler: 0.27.0
+
+  react-is@16.13.1: {}
+
+  react-use-measure@2.1.7(react-dom@19.2.4(react@19.2.4))(react@19.2.4):
+    dependencies:
+      react: 19.2.4
+    optionalDependencies:
+      react-dom: 19.2.4(react@19.2.4)
+
+  react@19.2.4: {}
+
   readable-stream@3.6.2:
     dependencies:
       inherits: 2.0.4
       string_decoder: 1.3.0
       util-deprecate: 1.0.2
+
+  require-from-string@2.0.2: {}
 
   rollup@4.57.1:
     dependencies:
@@ -2607,6 +3252,8 @@ snapshots:
 
   safe-buffer@5.2.1: {}
 
+  scheduler@0.27.0: {}
+
   shebang-command@2.0.0:
     dependencies:
       shebang-regex: 3.0.0
@@ -2621,6 +3268,13 @@ snapshots:
 
   stackback@0.0.2: {}
 
+  stats-gl@2.4.2(@types/three@0.172.0)(three@0.172.0):
+    dependencies:
+      '@types/three': 0.172.0
+      three: 0.172.0
+
+  stats.js@0.17.0: {}
+
   std-env@3.10.0: {}
 
   stream-browserify@3.0.0:
@@ -2633,6 +3287,26 @@ snapshots:
       safe-buffer: 5.2.1
 
   strnum@2.1.2: {}
+
+  suspend-react@0.1.3(react@19.2.4):
+    dependencies:
+      react: 19.2.4
+
+  three-mesh-bvh@0.7.8(three@0.172.0):
+    dependencies:
+      three: 0.172.0
+
+  three-stdlib@2.36.1(three@0.172.0):
+    dependencies:
+      '@types/draco3d': 1.4.10
+      '@types/offscreencanvas': 2019.7.3
+      '@types/webxr': 0.5.24
+      draco3d: 1.5.7
+      fflate: 0.6.10
+      potpack: 1.0.2
+      three: 0.172.0
+
+  three@0.172.0: {}
 
   tinybench@2.9.0: {}
 
@@ -2649,13 +3323,41 @@ snapshots:
 
   tinyspy@3.0.2: {}
 
+  troika-three-text@0.52.4(three@0.172.0):
+    dependencies:
+      bidi-js: 1.0.3
+      three: 0.172.0
+      troika-three-utils: 0.52.4(three@0.172.0)
+      troika-worker-utils: 0.52.0
+      webgl-sdf-generator: 1.1.1
+
+  troika-three-utils@0.52.4(three@0.172.0):
+    dependencies:
+      three: 0.172.0
+
+  troika-worker-utils@0.52.0: {}
+
   tslib@2.8.1: {}
+
+  tunnel-rat@0.1.2(@types/react@19.2.14)(react@19.2.4):
+    dependencies:
+      zustand: 4.5.7(@types/react@19.2.14)(react@19.2.4)
+    transitivePeerDependencies:
+      - '@types/react'
+      - immer
+      - react
 
   typescript@5.9.3: {}
 
   undici-types@6.21.0: {}
 
+  use-sync-external-store@1.6.0(react@19.2.4):
+    dependencies:
+      react: 19.2.4
+
   util-deprecate@1.0.2: {}
+
+  utility-types@3.11.0: {}
 
   vite-node@2.1.9(@types/node@22.19.11):
     dependencies:
@@ -2696,7 +3398,7 @@ snapshots:
       '@types/node': 22.19.11
       fsevents: 2.3.3
 
-  vitest@2.1.9(@types/node@22.19.11):
+  vitest@2.1.9(@types/node@22.19.11)(happy-dom@20.6.3):
     dependencies:
       '@vitest/expect': 2.1.9
       '@vitest/mocker': 2.1.9(vite@5.4.21(@types/node@22.19.11))
@@ -2720,6 +3422,7 @@ snapshots:
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 22.19.11
+      happy-dom: 20.6.3
     transitivePeerDependencies:
       - less
       - lightningcss
@@ -2731,6 +3434,12 @@ snapshots:
       - supports-color
       - terser
 
+  webgl-constants@1.1.1: {}
+
+  webgl-sdf-generator@1.1.1: {}
+
+  whatwg-mimetype@3.0.0: {}
+
   which@2.0.2:
     dependencies:
       isexe: 2.0.0
@@ -2739,3 +3448,18 @@ snapshots:
     dependencies:
       siginfo: 2.0.0
       stackback: 0.0.2
+
+  ws@8.19.0: {}
+
+  zustand@4.5.7(@types/react@19.2.14)(react@19.2.4):
+    dependencies:
+      use-sync-external-store: 1.6.0(react@19.2.4)
+    optionalDependencies:
+      '@types/react': 19.2.14
+      react: 19.2.4
+
+  zustand@5.0.11(@types/react@19.2.14)(react@19.2.4)(use-sync-external-store@1.6.0(react@19.2.4)):
+    optionalDependencies:
+      '@types/react': 19.2.14
+      react: 19.2.4
+      use-sync-external-store: 1.6.0(react@19.2.4)


### PR DESCRIPTION
## 概要

Phase 2 — ブラウザ専用パッケージ `@static3d/display` の完全実装。
`manifest.json` を読み込んで CDN(R2) からアセットを fetch するローダーと、
React/R3F ベースの 3D 空間コンポーネントを提供する。

## レビュー指摘対応済み

| 指摘 | 修正内容 |
|------|---------|
| `loadAll` のソートが無意味 | 無意味なソートを削除し FIFO キューに変更。Phase 3 TODO コメントを追記 |
| `require()` が ESM 環境で動作しない | `Stage.tsx` / `Overlay.tsx` を `useEffect + 動的 import()` に完全書き直し |

## @static3d/types への追加（既存変更なし）

| ファイル | 追加型 |
|---------|------|
| `loader.ts` | `LoaderOptions`, `LoadOptions`, `LoadAllOptions`, `ProgressEvent`, `LoadError`, `AssetResult` |
| `scene.ts` | `Vec3`, `CameraState`, `TransitionConfig`, `StageProps`, `RoomProps`, `SpotProps`, `OverlayProps` 他 |
| `index.ts` | 上記を全て re-export |

## @static3d/display 実装詳細

### Loader

```ts
const loader = new AssetLoader('https://pages.example.com/manifest.json', {
  concurrency: 4,   // 同時 DL 数
  retryCount: 3,    // 指数バックオフリトライ (retryDelay * 2^attempt)
  timeout: 30000,   // AbortSignal タイムアウト
  integrity: true,  // SubtleCrypto SHA-256 検証
});
await loader.init();
const blob = await loader.load('textures/albedo.png', { responseType: 'blob' });
// loadAll は FIFO キューで concurrency 制御
const map  = await loader.loadAll({ keys: ['models/scene.gltf'] });
loader.onProgress(e => console.log(e.percentage + '%'));
```

### React hooks

```tsx
<AssetProvider manifestUrl="/manifest.json">
  <Suspense fallback={<Loading />}>
    <MyModel /> {/* useAsset を呼ぶ → Suspense 対応 */}
  </Suspense>
</AssetProvider>

const { data, url } = useAsset<Blob>('textures/albedo.png');
const { loaded, total, percentage } = useAssetProgress();
```

### Scene コンポーネント (ESM 対応: `require()` ゼロ)

```tsx
<Stage environment="warehouse" ambientIntensity={0.5}>
  <Room camera={{ position: [0,5,10], target: [0,0,0] }}
        transition={{ duration: 1.5, easing: 'easeInOutCubic' }}>
    <Spot to="/products" highlight="outline" tooltip="商品を見る">
      <mesh><boxGeometry /><meshStandardMaterial /></mesh>
    </Spot>
    <Overlay position={[0,2,0]} anchor="bottom-center">
      <h1>ケーキ屋へようこそ</h1>
    </Overlay>
  </Room>
</Stage>
```

Stage / Overlay の peer dep ロード方式:
- `useEffect` で一度だけ `import('@react-three/fiber')` / `import('@react-three/drei')` を実行
- モジュールキャッシュで再マウント時の再 import を防止
- null (ロード中) / false (利用不可) / ready — の 3 状態でフォールバックを制御

### CameraEngine

```ts
const engine = new CameraEngine({ position: [0,5,10], target: [0,0,0] });
engine.transitionTo({ position: [10,0,0], target: [5,0,0] }, { duration: 1.5 });
engine.tick(delta); // useFrame コールバック内で呼ぶ → CameraEngineState
```

## テスト結果

| パッケージ | テストファイル | テスト数 |
|-----------|-------------|--------|
| @static3d/deploy | 7 files | 37 passed |
| @static3d/display | 3 files | 25 passed |
| **合計** | **10 files** | **62 passed** |

## 制約確認

- ✅ ブラウザ専用（Node.js の `fs`, `path` 等ゼロ）
- ✅ `@static3d/deploy` への依存なし
- ✅ peerDependencies 全て optional
- ✅ `require()` ゼロ（ESM 完全対応: 動的 `import()` 使用）
- ✅ `pnpm -r build` 型エラーなし
- ✅ 既存テスト 37件 変更なし