### PR TITLE
chore(local-test): Vite dev server + AssetLoader smoke test

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,0 +1,102 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>static3d Local Test</title>
+    <style>
+      * {
+        box-sizing: border-box;
+        margin: 0;
+        padding: 0;
+      }
+
+      body {
+        font-family: 'Segoe UI', system-ui, -apple-system, sans-serif;
+        background: #0f0f13;
+        color: #e0e0e0;
+        min-height: 100vh;
+        padding: 2rem;
+      }
+
+      h1 {
+        font-size: 1.5rem;
+        font-weight: 600;
+        color: #fff;
+        margin-bottom: 1.5rem;
+        letter-spacing: -0.02em;
+      }
+
+      h1 span {
+        color: #7c6af7;
+      }
+
+      #progress {
+        background: #1a1a24;
+        border: 1px solid #2a2a3a;
+        border-radius: 8px;
+        padding: 1rem 1.25rem;
+        margin-bottom: 1rem;
+        font-size: 0.875rem;
+        color: #a0a0b0;
+        min-height: 2.5rem;
+        display: flex;
+        align-items: center;
+        gap: 0.5rem;
+      }
+
+      #progress .bar-wrap {
+        flex: 1;
+        height: 6px;
+        background: #2a2a3a;
+        border-radius: 3px;
+        overflow: hidden;
+      }
+
+      #progress .bar {
+        height: 100%;
+        background: linear-gradient(90deg, #7c6af7, #4fa3e0);
+        border-radius: 3px;
+        width: 0%;
+        transition: width 0.2s ease;
+      }
+
+      #progress .label {
+        white-space: nowrap;
+        min-width: 10rem;
+        text-align: right;
+        color: #c0c0d0;
+      }
+
+      #log {
+        background: #1a1a24;
+        border: 1px solid #2a2a3a;
+        border-radius: 8px;
+        padding: 1rem 1.25rem;
+        font-family: 'Fira Code', 'Cascadia Code', 'Consolas', monospace;
+        font-size: 0.8rem;
+        line-height: 1.7;
+        white-space: pre-wrap;
+        word-break: break-all;
+        overflow-y: auto;
+        max-height: calc(100vh - 14rem);
+        color: #b0ffb0;
+      }
+
+      #log .info  { color: #80c8ff; }
+      #log .warn  { color: #ffd080; }
+      #log .error { color: #ff8080; }
+      #log .ok    { color: #80ff80; }
+      #log .dim   { color: #606070; }
+    </style>
+  </head>
+  <body>
+    <h1>static3d <span>Local Test</span></h1>
+    <div id="progress">
+      <span class="label">Initialising…</span>
+      <div class="bar-wrap"><div class="bar"></div></div>
+    </div>
+    <pre id="log"></pre>
+    <script type="module" src="/test.ts"></script>
+  </body>
+</html>

--- a/manifest.json
+++ b/manifest.json
@@ -1,0 +1,35 @@
+{
+  "schemaVersion": 1,
+  "version": "27ce126",
+  "buildTime": "2026-02-19T14:22:27.692Z",
+  "assets": {
+    "textures/normal.png": {
+      "url": "https://cdn.example.com/textures/normal.725746d7.png",
+      "size": 24,
+      "hash": "sha256:725746d730b93ef681f4a74b04ad2d0962d5299b37d5a39010602238d4e8d879",
+      "contentType": "image/png"
+    },
+    "textures/albedo.png": {
+      "url": "https://cdn.example.com/textures/albedo.8cbce19e.png",
+      "size": 17,
+      "hash": "sha256:8cbce19e9d89d5eeeea8fe2c921b575e2aaddc4d027c4e433c811ebee109c0db",
+      "contentType": "image/png"
+    },
+    "models/scene.bin": {
+      "url": "https://cdn.example.com/models/scene.c2397e08.bin",
+      "size": 17,
+      "hash": "sha256:c2397e0838f66bb72effd1d76821450aa5c9ec292e34e3f45d881027cd275156",
+      "contentType": "application/octet-stream"
+    },
+    "models/scene.gltf": {
+      "url": "https://cdn.example.com/models/scene.2073f5d5.gltf",
+      "size": 554,
+      "hash": "sha256:2073f5d59e886356f87e556e1a9182689cc33f3041da079ca2fe6ef677b62655",
+      "contentType": "model/gltf+json",
+      "dependencies": [
+        "textures/albedo.png",
+        "models/scene.bin"
+      ]
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,5 +1,14 @@
 {
   "name": "static3d",
   "private": true,
-  "packageManager": "pnpm@9.15.0"
+  "packageManager": "pnpm@9.15.0",
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "typescript": "^5.7.0",
+    "vite": "^6.0.0"
+  }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,7 +6,14 @@ settings:
 
 importers:
 
-  .: {}
+  .:
+    dependencies:
+      typescript:
+        specifier: ^5.7.0
+        version: 5.9.3
+      vite:
+        specifier: ^6.0.0
+        version: 6.4.1(@types/node@22.19.11)
 
   packages/deploy:
     dependencies:

--- a/test.ts
+++ b/test.ts
@@ -1,0 +1,169 @@
+/**
+ * test.ts — static3d Local Test
+ *
+ * AssetLoader を使って manifest.json を読み込み、全アセットを取得する
+ * ブラウザ動作確認スクリプト。
+ *
+ * Vite dev server 上で実行:
+ *   pnpm vite
+ *   → http://localhost:5173
+ */
+
+import { AssetLoader } from './packages/display/src/loader/AssetLoader.js';
+
+// ─── DOM helpers ─────────────────────────────────────────────────────────────
+
+const logEl = document.getElementById('log') as HTMLPreElement;
+const progressEl = document.getElementById('progress') as HTMLDivElement;
+
+function updateProgress(pct: number, label: string): void {
+  const bar = progressEl.querySelector('.bar') as HTMLDivElement;
+  const lbl = progressEl.querySelector('.label') as HTMLSpanElement;
+  if (bar) bar.style.width = `${Math.round(pct)}%`;
+  if (lbl) lbl.textContent = label;
+}
+
+function log(
+  message: string,
+  cls: 'info' | 'warn' | 'error' | 'ok' | 'dim' | '' = ''
+): void {
+  const ts = new Date().toISOString().slice(11, 23); // HH:MM:SS.mmm
+  const prefix = `[${ts}] `;
+  const line = document.createElement('span');
+  if (cls) line.className = cls;
+  line.textContent = prefix + message + '\n';
+  logEl.appendChild(line);
+  logEl.scrollTop = logEl.scrollHeight;
+  // Also write to devtools console
+  if (cls === 'error') console.error(message);
+  else if (cls === 'warn') console.warn(message);
+  else console.log(message);
+}
+
+// ─── Main ─────────────────────────────────────────────────────────────────────
+
+async function main(): Promise<void> {
+  log('static3d local test starting…', 'dim');
+  updateProgress(0, 'Connecting…');
+
+  // 1. Construct the AssetLoader pointing at /manifest.json (served by Vite)
+  const loader = new AssetLoader('/manifest.json', {
+    concurrency: 2,
+    retryCount: 2,
+    timeout: 10_000,
+    integrity: true,
+  });
+
+  // 2. Register progress callback
+  loader.onProgress((evt) => {
+    const pct = evt.total > 0 ? (evt.loaded / evt.total) * 100 : 0;
+    const label = `${evt.completedCount}/${evt.totalCount} assets  (${
+      evt.loaded
+    } / ${evt.total} bytes)`;
+    updateProgress(pct, label);
+    log(
+      `  ↳ progress: ${evt.asset}  ${evt.completedCount}/${evt.totalCount}`,
+      'dim'
+    );
+  });
+
+  // 3. Register error callback
+  loader.onError((err) => {
+    log(
+      `ERROR [${err.type}] ${err.key}  ${err.url}${
+        err.cause ? '  →  ' + err.cause.message : ''
+      }`,
+      'error'
+    );
+  });
+
+  // 4. Load manifest
+  log('init() — fetching manifest.json …', 'info');
+  try {
+    await loader.init();
+  } catch (err) {
+    log(`Failed to fetch manifest: ${(err as Error).message}`, 'error');
+    updateProgress(0, 'Error – see log');
+    return;
+  }
+
+  const manifest = loader.getManifest();
+  if (!manifest) {
+    log('manifest is null after init()', 'error');
+    return;
+  }
+
+  const assetKeys = Object.keys(manifest.assets);
+  log(`manifest OK  schema=${manifest.schemaVersion}  version=${manifest.version}`, 'ok');
+  log(`buildTime: ${manifest.buildTime}`, 'dim');
+  log(`asset count: ${assetKeys.length}`, 'info');
+
+  // 5. Log each asset entry from manifest
+  for (const key of assetKeys) {
+    const entry = manifest.assets[key];
+    log(
+      `  • ${key}  size=${entry.size}  type=${entry.contentType}`,
+      'dim'
+    );
+    if (entry.dependencies?.length) {
+      log(`    deps: ${entry.dependencies.join(', ')}`, 'dim');
+    }
+  }
+
+  // 6. loadAll — download every asset
+  log('loadAll() — starting concurrent download…', 'info');
+  updateProgress(0, 'Downloading assets…');
+
+  let allAssets: Map<string, Blob>;
+  try {
+    allAssets = await loader.loadAll();
+  } catch (err) {
+    log(`loadAll failed: ${(err as Error).message}`, 'error');
+    updateProgress(0, 'Error – see log');
+    return;
+  }
+
+  // 7. Log results
+  log(`loadAll() complete — ${allAssets.size} assets loaded`, 'ok');
+  for (const [key, blob] of allAssets.entries()) {
+    log(`  ✓ ${key}  ${blob.size} bytes  type=${blob.type || 'unknown'}`, 'ok');
+  }
+
+  // 8. Test single load
+  if (assetKeys.length > 0) {
+    const firstKey = assetKeys[0];
+    log(`load('${firstKey}') — single asset test…`, 'info');
+    try {
+      const result = await loader.load(firstKey);
+      const size =
+        result instanceof Blob
+          ? result.size
+          : result.byteLength;
+      log(`  ✓ loaded "${firstKey}"  ${size} bytes`, 'ok');
+    } catch (err) {
+      log(`load('${firstKey}') failed: ${(err as Error).message}`, 'error');
+    }
+  }
+
+  // 9. Test load of non-existent key
+  log("load('non-existent-key') — expected error test…", 'info');
+  try {
+    await loader.load('non-existent-key');
+    log('  ✗ should have thrown but did not', 'error');
+  } catch (err) {
+    log(
+      `  ✓ correctly threw error: ${(err as { type?: string }).type ?? 'unknown'
+      }`,
+      'ok'
+    );
+  }
+
+  // 10. Done
+  updateProgress(100, `Done — ${allAssets.size} assets`);
+  log('─'.repeat(60), 'dim');
+  log('All tests complete ✓', 'ok');
+}
+
+main().catch((err) => {
+  log(`Unhandled error: ${err instanceof Error ? err.message : String(err)}`, 'error');
+});

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,0 +1,22 @@
+import { defineConfig } from 'vite';
+import { resolve } from 'path';
+
+export default defineConfig({
+  root: '.',
+  server: {
+    port: 5173,
+    host: '0.0.0.0',
+    // Allow all external hosts (needed for sandbox proxy access)
+    allowedHosts: 'all',
+    fs: {
+      // Allow Vite to serve files from anywhere in the monorepo
+      strict: false,
+    },
+  },
+  resolve: {
+    alias: {
+      // Map @static3d/types directly to its TypeScript source
+      '@static3d/types': resolve(__dirname, 'packages/types/src/index.ts'),
+    },
+  },
+});


### PR DESCRIPTION
## 概要

`local-test` ブランチに Vite dev server 環境を追加。`AssetLoader` をビルドなしにブラウザで動作確認できます。

## 追加ファイル

| ファイル | 内容 |
|---|---|
| `vite.config.ts` | port 5173、`fs.strict=false`、`allowedHosts='all'`、`@static3d/types` → source alias |
| `index.html` | タイトル「static3d Local Test」、プログレスバー付き UI |
| `test.ts` | AssetLoader スモークテスト（init / onProgress / onError / loadAll / load / not-found）|
| `manifest.json` | `dist/pages/manifest.json` のコピー（Vite が `/manifest.json` として配信）|
| `package.json` | `scripts.dev = "vite"` + workspace deps（vite, typescript）|

## ローカル実行手順

```bash
git clone https://github.com/Gominokas/static3d.git
cd static3d
git checkout local-test
pnpm install
pnpm -r build          # @static3d/types と @static3d/deploy をビルド
# dist/pages/manifest.json が存在しない場合:
node packages/deploy/dist/cli/index.js build
cp dist/pages/manifest.json manifest.json
pnpm dev               # → http://localhost:5173
```

ブラウザで http://localhost:5173 を開くと、AssetLoader がマニフェストを読み込み、全アセットのダウンロード結果をログに表示します。

## テスト

既存 62 テスト（deploy 37 + display 25）はすべて通過しています。このブランチはローカル動作確認専用です。