### PR TITLE
feat(deploy): Vite プラグイン本格実装 — dev server + build pipeline 統合

### DIFF
--- a/packages/deploy/package.json
+++ b/packages/deploy/package.json
@@ -6,6 +6,10 @@
     "static3d-deploy": "./dist/cli/index.js"
   },
   "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    },
     "./vite": {
       "types": "./dist/vite/plugin.d.ts",
       "import": "./dist/vite/plugin.js"

--- a/packages/deploy/src/index.ts
+++ b/packages/deploy/src/index.ts
@@ -1,0 +1,20 @@
+/**
+ * @static3d/deploy — main entry point
+ *
+ * CLI 以外から直接インポートできる公開 API をエクスポートする。
+ */
+
+// ビルドパイプライン
+export { build } from './build/index.js';
+
+// 設定ローダー / バリデーター
+export { loadConfig, validateDeployConfig, ConfigError } from './config/schema.js';
+
+// R2 アップロード / Pages デプロイ
+export { uploadToR2 } from './push/r2.js';
+export { deployToPages } from './push/pages.js';
+export { push } from './push/index.js';
+
+// 型
+export type { CollectedAsset } from './build/collect.js';
+export type { HashedAsset } from './build/hash.js';

--- a/packages/deploy/src/tests/devManifest.test.ts
+++ b/packages/deploy/src/tests/devManifest.test.ts
@@ -1,0 +1,170 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdirSync, writeFileSync, rmSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { buildDevManifest, parseGltfDependencies } from '../vite/devManifest.js';
+
+// ────────────────────────────────────────────────────────────────────────────
+// fixtures
+// ────────────────────────────────────────────────────────────────────────────
+
+let tmpDir: string;
+
+beforeEach(() => {
+  tmpDir = join(tmpdir(), `static3d-devmanifest-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+  mkdirSync(join(tmpDir, 'textures'), { recursive: true });
+  mkdirSync(join(tmpDir, 'models'), { recursive: true });
+  writeFileSync(join(tmpDir, 'textures', 'albedo.png'), 'PNG_DATA');
+  writeFileSync(join(tmpDir, 'textures', 'normal.png'), 'PNG_NORM');
+  writeFileSync(join(tmpDir, 'models', 'scene.bin'), 'BIN_DATA');
+  writeFileSync(
+    join(tmpDir, 'models', 'scene.gltf'),
+    JSON.stringify({
+      buffers: [{ uri: 'scene.bin' }],
+      images: [{ uri: '../textures/albedo.png' }],
+    })
+  );
+});
+
+afterEach(() => {
+  rmSync(tmpDir, { recursive: true, force: true });
+});
+
+// ────────────────────────────────────────────────────────────────────────────
+// buildDevManifest
+// ────────────────────────────────────────────────────────────────────────────
+
+describe('buildDevManifest', () => {
+  it('returns schemaVersion 1, version "dev"', async () => {
+    const manifest = await buildDevManifest(tmpDir);
+    expect(manifest.schemaVersion).toBe(1);
+    expect(manifest.version).toBe('dev');
+  });
+
+  it('sets buildTime to an ISO string', async () => {
+    const manifest = await buildDevManifest(tmpDir);
+    expect(() => new Date(manifest.buildTime)).not.toThrow();
+    expect(manifest.buildTime).toMatch(/^\d{4}-\d{2}-\d{2}T/);
+  });
+
+  it('generates entries for all files', async () => {
+    const manifest = await buildDevManifest(tmpDir);
+    const keys = Object.keys(manifest.assets).sort();
+    expect(keys).toContain('textures/albedo.png');
+    expect(keys).toContain('textures/normal.png');
+    expect(keys).toContain('models/scene.bin');
+    expect(keys).toContain('models/scene.gltf');
+  });
+
+  it('sets url to /cdn/<key>', async () => {
+    const manifest = await buildDevManifest(tmpDir);
+    expect(manifest.assets['textures/albedo.png'].url).toBe('/cdn/textures/albedo.png');
+    expect(manifest.assets['models/scene.gltf'].url).toBe('/cdn/models/scene.gltf');
+  });
+
+  it('sets hash to empty string (integrity skip in dev)', async () => {
+    const manifest = await buildDevManifest(tmpDir);
+    for (const entry of Object.values(manifest.assets)) {
+      expect(entry.hash).toBe('');
+    }
+  });
+
+  it('sets correct contentType via mime-types', async () => {
+    const manifest = await buildDevManifest(tmpDir);
+    expect(manifest.assets['textures/albedo.png'].contentType).toBe('image/png');
+    expect(manifest.assets['models/scene.bin'].contentType).toBe('application/octet-stream');
+    expect(manifest.assets['models/scene.gltf'].contentType).toContain('gltf');
+  });
+
+  it('sets size in bytes', async () => {
+    const manifest = await buildDevManifest(tmpDir);
+    expect(manifest.assets['textures/albedo.png'].size).toBe(8); // "PNG_DATA"
+    expect(manifest.assets['models/scene.bin'].size).toBe(8);    // "BIN_DATA"
+  });
+
+  it('adds dependencies for .gltf files', async () => {
+    const manifest = await buildDevManifest(tmpDir);
+    const gltfEntry = manifest.assets['models/scene.gltf'];
+    expect(gltfEntry.dependencies).toBeDefined();
+    expect(gltfEntry.dependencies).toContain('models/scene.bin');
+    expect(gltfEntry.dependencies).toContain('textures/albedo.png');
+  });
+
+  it('does not add dependencies field for non-gltf files', async () => {
+    const manifest = await buildDevManifest(tmpDir);
+    expect(manifest.assets['textures/albedo.png'].dependencies).toBeUndefined();
+    expect(manifest.assets['models/scene.bin'].dependencies).toBeUndefined();
+  });
+
+  it('respects ignorePatterns', async () => {
+    writeFileSync(join(tmpDir, 'design.psd'), 'PSD');
+    const manifest = await buildDevManifest(tmpDir, ['**/*.psd']);
+    expect(Object.keys(manifest.assets)).not.toContain('design.psd');
+  });
+
+  it('returns empty assets for empty directory', async () => {
+    const emptyDir = join(tmpdir(), `static3d-empty-${Date.now()}`);
+    mkdirSync(emptyDir, { recursive: true });
+    try {
+      const manifest = await buildDevManifest(emptyDir);
+      expect(Object.keys(manifest.assets)).toHaveLength(0);
+    } finally {
+      rmSync(emptyDir, { recursive: true, force: true });
+    }
+  });
+
+  it('handles data: URI buffers without adding them as dependencies', async () => {
+    writeFileSync(
+      join(tmpDir, 'models', 'embedded.gltf'),
+      JSON.stringify({
+        buffers: [{ uri: 'data:application/octet-stream;base64,AAAA' }],
+        images: [],
+      })
+    );
+    const manifest = await buildDevManifest(tmpDir);
+    const embedded = manifest.assets['models/embedded.gltf'];
+    // data: URI は依存として含まれない
+    if (embedded.dependencies) {
+      expect(embedded.dependencies.some((d) => d.startsWith('data:'))).toBe(false);
+    }
+  });
+});
+
+// ────────────────────────────────────────────────────────────────────────────
+// parseGltfDependencies
+// ────────────────────────────────────────────────────────────────────────────
+
+describe('parseGltfDependencies', () => {
+  it('returns buffer and image URIs as deferredDir-relative keys', () => {
+    const gltfPath = join(tmpDir, 'models', 'scene.gltf');
+    const deps = parseGltfDependencies(gltfPath, tmpDir);
+    expect(deps).toContain('models/scene.bin');
+    expect(deps).toContain('textures/albedo.png');
+  });
+
+  it('returns empty array for invalid JSON', () => {
+    const badPath = join(tmpDir, 'bad.gltf');
+    writeFileSync(badPath, 'NOT JSON');
+    expect(parseGltfDependencies(badPath, tmpDir)).toEqual([]);
+  });
+
+  it('returns empty array for missing file', () => {
+    expect(parseGltfDependencies('/nonexistent/file.gltf', tmpDir)).toEqual([]);
+  });
+
+  it('ignores data: URI buffers', () => {
+    const p = join(tmpDir, 'models', 'inline.gltf');
+    writeFileSync(
+      p,
+      JSON.stringify({ buffers: [{ uri: 'data:application/octet-stream;base64,AA==' }] })
+    );
+    const deps = parseGltfDependencies(p, tmpDir);
+    expect(deps).toHaveLength(0);
+  });
+
+  it('handles gltf with no buffers or images', () => {
+    const p = join(tmpDir, 'models', 'empty.gltf');
+    writeFileSync(p, JSON.stringify({ asset: { version: '2.0' } }));
+    expect(parseGltfDependencies(p, tmpDir)).toEqual([]);
+  });
+});

--- a/packages/deploy/src/tests/plugin.integration.test.ts
+++ b/packages/deploy/src/tests/plugin.integration.test.ts
@@ -1,0 +1,292 @@
+/**
+ * plugin.integration.test.ts
+ *
+ * Vite build API を直接呼んで closeBundle フックが正しく動くことを検証する。
+ * dev server のミドルウェアは HTTP を立てずに直接テストする。
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { mkdirSync, writeFileSync, rmSync, readFileSync, existsSync } from 'node:fs';
+import { join, resolve } from 'node:path';
+import { tmpdir } from 'node:os';
+import type { IncomingMessage, ServerResponse } from 'node:http';
+
+// ────────────────────────────────────────────────────────────────────────────
+// helpers
+// ────────────────────────────────────────────────────────────────────────────
+
+let tmpDir: string;
+let deferredDir: string;
+let immediateDir: string;
+let configPath: string;
+
+function setupFixture() {
+  tmpDir = join(
+    tmpdir(),
+    `static3d-plugin-${Date.now()}-${Math.random().toString(36).slice(2)}`
+  );
+  deferredDir = join(tmpDir, 'src/assets/deferred');
+  immediateDir = join(tmpDir, 'src/assets/immediate');
+  mkdirSync(join(deferredDir, 'textures'), { recursive: true });
+  mkdirSync(join(deferredDir, 'models'), { recursive: true });
+  mkdirSync(immediateDir, { recursive: true });
+
+  writeFileSync(join(deferredDir, 'textures', 'albedo.png'), 'PNG_DATA');
+  writeFileSync(join(deferredDir, 'models', 'scene.bin'), 'BIN_DATA');
+  writeFileSync(
+    join(deferredDir, 'models', 'scene.gltf'),
+    JSON.stringify({ asset: { version: '2.0' }, buffers: [{ uri: 'scene.bin' }] })
+  );
+
+  // static3d.config.json を tmpDir に作成
+  configPath = join(tmpDir, 'static3d.config.json');
+  writeFileSync(
+    configPath,
+    JSON.stringify({
+      schemaVersion: 1,
+      project: 'test',
+      deploy: {
+        pages: { outputDir: join(tmpDir, 'dist/pages') },
+        cdn: {
+          provider: 'cloudflare-r2',
+          bucket: 'test-bucket',
+          baseUrl: 'https://cdn.example.com',
+        },
+        assets: {
+          immediateDir,
+          deferredDir,
+          hashLength: 8,
+        },
+      },
+    })
+  );
+}
+
+function teardown() {
+  rmSync(tmpDir, { recursive: true, force: true });
+}
+
+// ────────────────────────────────────────────────────────────────────────────
+// devServer middleware unit tests (no HTTP)
+// ────────────────────────────────────────────────────────────────────────────
+
+describe('manifestMiddleware', () => {
+  beforeEach(setupFixture);
+  afterEach(teardown);
+
+  it('responds to GET /manifest.json with JSON', async () => {
+    const { manifestMiddleware } = await import('../vite/devServer.js');
+    const mw = manifestMiddleware({ deferredDir });
+
+    let responseBody = '';
+    let contentType = '';
+    const req = { url: '/manifest.json' } as IncomingMessage;
+    const res = {
+      setHeader(k: string, v: string) { if (k === 'Content-Type') contentType = v; },
+      end(body: string) { responseBody = body; },
+      statusCode: 200,
+    } as unknown as ServerResponse;
+    const next = vi.fn();
+
+    // ミドルウェアは async なので少し待つ
+    mw(req, res, next);
+    await new Promise((r) => setTimeout(r, 200));
+
+    expect(next).not.toHaveBeenCalled();
+    expect(contentType).toContain('application/json');
+    const parsed = JSON.parse(responseBody);
+    expect(parsed.version).toBe('dev');
+    expect(parsed.schemaVersion).toBe(1);
+    expect(typeof parsed.assets).toBe('object');
+  });
+
+  it('calls next() for non-/manifest.json paths', async () => {
+    const { manifestMiddleware } = await import('../vite/devServer.js');
+    const mw = manifestMiddleware({ deferredDir });
+
+    const req = { url: '/other.json' } as IncomingMessage;
+    const res = {} as ServerResponse;
+    const next = vi.fn();
+
+    mw(req, res, next);
+    await new Promise((r) => setTimeout(r, 50));
+
+    expect(next).toHaveBeenCalled();
+  });
+});
+
+describe('cdnMiddleware', () => {
+  beforeEach(setupFixture);
+  afterEach(teardown);
+
+  it('serves a file from deferredDir for /cdn/* requests', async () => {
+    const { cdnMiddleware } = await import('../vite/devServer.js');
+    const mw = cdnMiddleware({ deferredDir });
+
+    let responseBody: Buffer | string = '';
+    let contentType = '';
+    const req = { url: '/cdn/textures/albedo.png' } as IncomingMessage;
+    const res = {
+      setHeader(k: string, v: string) { if (k === 'Content-Type') contentType = v; },
+      end(body: Buffer | string) { responseBody = body; },
+      statusCode: 200,
+    } as unknown as ServerResponse;
+    const next = vi.fn();
+
+    mw(req, res, next);
+
+    expect(next).not.toHaveBeenCalled();
+    expect(contentType).toBe('image/png');
+    expect(responseBody.toString()).toBe('PNG_DATA');
+  });
+
+  it('calls next() when file does not exist', async () => {
+    const { cdnMiddleware } = await import('../vite/devServer.js');
+    const mw = cdnMiddleware({ deferredDir });
+
+    const req = { url: '/cdn/nonexistent.png' } as IncomingMessage;
+    const res = {} as ServerResponse;
+    const next = vi.fn();
+
+    mw(req, res, next);
+
+    expect(next).toHaveBeenCalled();
+  });
+
+  it('calls next() for non-/cdn/ paths', async () => {
+    const { cdnMiddleware } = await import('../vite/devServer.js');
+    const mw = cdnMiddleware({ deferredDir });
+
+    const req = { url: '/static/logo.png' } as IncomingMessage;
+    const res = {} as ServerResponse;
+    const next = vi.fn();
+
+    mw(req, res, next);
+
+    expect(next).toHaveBeenCalled();
+  });
+
+  it('rejects path traversal attempts', async () => {
+    const { cdnMiddleware } = await import('../vite/devServer.js');
+    const mw = cdnMiddleware({ deferredDir });
+
+    let statusCode = 200;
+    let responseBody = '';
+    const req = { url: '/cdn/../../../etc/passwd' } as IncomingMessage;
+    const res = {
+      setHeader: vi.fn(),
+      end(body: string) { responseBody = body; },
+      get statusCode() { return statusCode; },
+      set statusCode(v: number) { statusCode = v; },
+    } as unknown as ServerResponse;
+    const next = vi.fn();
+
+    mw(req, res, next);
+
+    // path traversal は 400 か next() のどちらか
+    // decoded に ".." が含まれるので 400 になる
+    expect(statusCode).toBe(400);
+    expect(next).not.toHaveBeenCalled();
+  });
+});
+
+// ────────────────────────────────────────────────────────────────────────────
+// plugin factory
+// ────────────────────────────────────────────────────────────────────────────
+
+describe('static3d plugin', () => {
+  it('has the correct plugin name', async () => {
+    const { static3d } = await import('../vite/plugin.js');
+    const plugin = static3d();
+    expect(plugin.name).toBe('static3d');
+  });
+
+  it('exports static3d and static3dDeploy (alias)', async () => {
+    const mod = await import('../vite/plugin.js');
+    expect(typeof mod.static3d).toBe('function');
+    expect(typeof mod.static3dDeploy).toBe('function');
+    // alias は同一関数
+    expect(mod.static3dDeploy).toBe(mod.static3d);
+  });
+
+  it('returns a Vite Plugin object with required hooks', async () => {
+    const { static3d } = await import('../vite/plugin.js');
+    const plugin = static3d();
+    expect(typeof plugin.configResolved).toBe('function');
+    expect(typeof plugin.configureServer).toBe('function');
+    expect(typeof plugin.closeBundle).toBe('function');
+  });
+});
+
+// ────────────────────────────────────────────────────────────────────────────
+// build integration — closeBundle
+// ────────────────────────────────────────────────────────────────────────────
+
+describe('static3d plugin closeBundle (build mode)', () => {
+  beforeEach(setupFixture);
+  afterEach(teardown);
+
+  it('runs asset pipeline and outputs manifest.json in build mode', async () => {
+    const { static3d } = await import('../vite/plugin.js');
+    const plugin = static3d({ config: configPath });
+
+    const pagesOutputDir = join(tmpDir, 'dist/pages');
+
+    // configResolved を build モードで呼ぶ
+    (plugin.configResolved as Function)({
+      command: 'build',
+      build: { outDir: join(tmpDir, 'dist') },
+    });
+
+    // closeBundle を呼ぶ（this は Rollup PluginContext の stub）
+    const ctx = { warn: vi.fn(), error: vi.fn() };
+    await (plugin.closeBundle as Function).call(ctx);
+
+    // dist/pages/manifest.json が生成されていること
+    const manifestPath = join(pagesOutputDir, 'manifest.json');
+    expect(existsSync(manifestPath)).toBe(true);
+
+    const manifest = JSON.parse(readFileSync(manifestPath, 'utf-8'));
+    expect(manifest.schemaVersion).toBe(1);
+    expect(typeof manifest.assets).toBe('object');
+
+    // 全 3 アセット (albedo.png, scene.bin, scene.gltf) が含まれること
+    const keys = Object.keys(manifest.assets);
+    expect(keys.length).toBe(3);
+    expect(keys.some((k) => k.endsWith('.gltf'))).toBe(true);
+  }, 20_000);
+
+  it('does not run asset pipeline in dev mode', async () => {
+    const { static3d } = await import('../vite/plugin.js');
+    const plugin = static3d({ config: configPath });
+
+    (plugin.configResolved as Function)({
+      command: 'serve',   // dev モード
+      build: { outDir: join(tmpDir, 'dist') },
+    });
+
+    const ctx = { warn: vi.fn(), error: vi.fn() };
+    await (plugin.closeBundle as Function).call(ctx);
+
+    // dev モードでは dist/pages/manifest.json が生成されない
+    const manifestPath = join(tmpDir, 'dist/pages', 'manifest.json');
+    expect(existsSync(manifestPath)).toBe(false);
+  });
+
+  it('calls this.warn instead of throwing when config is invalid', async () => {
+    const { static3d } = await import('../vite/plugin.js');
+    const plugin = static3d({ config: '/nonexistent/static3d.config.json' });
+
+    (plugin.configResolved as Function)({
+      command: 'build',
+      build: { outDir: join(tmpDir, 'dist') },
+    });
+
+    const ctx = { warn: vi.fn(), error: vi.fn() };
+    // エラーをスローせず、this.warn を呼ぶこと
+    await expect(
+      (plugin.closeBundle as Function).call(ctx)
+    ).resolves.toBeUndefined();
+    expect(ctx.warn).toHaveBeenCalled();
+  });
+});

--- a/packages/deploy/src/vite/devManifest.ts
+++ b/packages/deploy/src/vite/devManifest.ts
@@ -1,0 +1,114 @@
+/**
+ * devManifest.ts
+ *
+ * deferred/ ディレクトリの中身をスキャンして、
+ * Vite dev server 用のインメモリ manifest を動的に生成する。
+ *
+ * 仕様:
+ *  - version: "dev" 固定
+ *  - hash:    "" (空文字) — dev 時は integrity 検証をスキップ
+ *  - url:     "/cdn/<key>"  — Vite dev server 上のローカルパス
+ *  - dependencies: .gltf ファイルの bufferViews/images から URI 解析して設定
+ */
+
+import { resolve, relative } from 'node:path';
+import { statSync, readFileSync } from 'node:fs';
+import { glob } from 'glob';
+import { lookup } from 'mime-types';
+import type { DeployManifest, AssetEntry } from '@static3d/types';
+
+// ────────────────────────────────────────────────────────────────────────────
+// gltf 依存解析
+// ────────────────────────────────────────────────────────────────────────────
+
+interface GltfLike {
+  bufferViews?: unknown[];
+  buffers?: Array<{ uri?: string }>;
+  images?: Array<{ uri?: string }>;
+}
+
+/**
+ * .gltf ファイルのバッファ/テクスチャ URI を読み取り、
+ * deferredDir 相対のキーとして返す。
+ * 解析失敗時は空配列を返す（ビルドを止めない）。
+ */
+export function parseGltfDependencies(
+  gltfAbsPath: string,
+  deferredDir: string
+): string[] {
+  try {
+    const raw = readFileSync(gltfAbsPath, 'utf-8');
+    const gltf = JSON.parse(raw) as GltfLike;
+    const uris: string[] = [];
+
+    for (const buf of gltf.buffers ?? []) {
+      if (buf.uri && !buf.uri.startsWith('data:')) uris.push(buf.uri);
+    }
+    for (const img of gltf.images ?? []) {
+      if (img.uri && !img.uri.startsWith('data:')) uris.push(img.uri);
+    }
+
+    // gltf と同ディレクトリからの相対 URI を deferredDir 相対に変換
+    const gltfDir = resolve(gltfAbsPath, '..');
+    return uris.map((uri) => {
+      const abs = resolve(gltfDir, uri);
+      return relative(deferredDir, abs).replace(/\\/g, '/');
+    });
+  } catch {
+    return [];
+  }
+}
+
+// ────────────────────────────────────────────────────────────────────────────
+// dev 用 manifest 生成
+// ────────────────────────────────────────────────────────────────────────────
+
+/**
+ * deferredDir をスキャンして DeployManifest を返す。
+ * 非同期（glob を使うため）。
+ */
+export async function buildDevManifest(
+  deferredDir: string,
+  ignorePatterns: string[] = []
+): Promise<DeployManifest> {
+  const absDeferred = resolve(deferredDir);
+
+  const files = await glob('**/*', {
+    cwd: absDeferred,
+    nodir: true,
+    ignore: ignorePatterns,
+    absolute: true,
+  });
+
+  const assets: Record<string, AssetEntry> = {};
+
+  for (const absPath of files) {
+    const key = relative(absDeferred, absPath).replace(/\\/g, '/');
+    const stat = statSync(absPath);
+    const contentType = lookup(key) || 'application/octet-stream';
+
+    const entry: AssetEntry = {
+      url: `/cdn/${key}`,
+      size: stat.size,
+      hash: '',           // dev 時は integrity 検証スキップ
+      contentType,
+    };
+
+    // .gltf: 依存アセットを解析して dependencies フィールドに設定
+    if (key.endsWith('.gltf')) {
+      const deps = parseGltfDependencies(absPath, absDeferred);
+      if (deps.length > 0) {
+        entry.dependencies = deps;
+      }
+    }
+
+    assets[key] = entry;
+  }
+
+  return {
+    schemaVersion: 1,
+    version: 'dev',
+    buildTime: new Date().toISOString(),
+    assets,
+  };
+}

--- a/packages/deploy/src/vite/devServer.ts
+++ b/packages/deploy/src/vite/devServer.ts
@@ -1,0 +1,194 @@
+/**
+ * devServer.ts
+ *
+ * Vite dev server に以下の 2 つのミドルウェアを追加する:
+ *
+ *  GET /manifest.json
+ *    deferred/ ディレクトリをスキャンして dev 用 manifest を動的生成し、
+ *    JSON レスポンスとして返す。ファイル変更を検知して次回リクエストで
+ *    再生成する（キャッシュを持つがウォッチャーで無効化する）。
+ *
+ *  GET /cdn/*
+ *    deferred/ のファイルをそのまま配信する（ハッシュなし）。
+ *    パストラバーサル対策・MIME type 付与あり。
+ */
+
+import { resolve, join } from 'node:path';
+import { existsSync, statSync, readFileSync } from 'node:fs';
+import { watch } from 'node:fs';
+import type { IncomingMessage, ServerResponse } from 'node:http';
+import type { ViteDevServer } from 'vite';
+
+/** connect ミドルウェア関数の型 (@types/connect 不要) */
+type NextHandleFunction = (
+  req: IncomingMessage,
+  res: ServerResponse,
+  next: (err?: unknown) => void
+) => void;
+import { lookup } from 'mime-types';
+import { buildDevManifest } from './devManifest.js';
+
+// ────────────────────────────────────────────────────────────────────────────
+// 型
+// ────────────────────────────────────────────────────────────────────────────
+
+export interface DevServerOptions {
+  deferredDir: string;
+  ignorePatterns?: string[];
+}
+
+// ────────────────────────────────────────────────────────────────────────────
+// マニフェスト キャッシュ
+// ────────────────────────────────────────────────────────────────────────────
+
+/** JSON 文字列キャッシュ。null のとき次回リクエストで再生成 */
+let manifestCache: string | null = null;
+let fsWatcher: ReturnType<typeof watch> | null = null;
+
+/** キャッシュを無効化する */
+function invalidateCache(): void {
+  manifestCache = null;
+}
+
+/**
+ * deferredDir 以下のファイル変更を監視してキャッシュを自動無効化する。
+ * 多重登録しないよう、既存の watcher は先に閉じる。
+ */
+export function watchDeferredDir(deferredDir: string): void {
+  if (fsWatcher) {
+    try { fsWatcher.close(); } catch { /* ignore */ }
+    fsWatcher = null;
+  }
+  if (!existsSync(deferredDir)) return;
+
+  try {
+    fsWatcher = watch(deferredDir, { recursive: true }, () => {
+      invalidateCache();
+    });
+    // プロセス終了時に watcher をクリーンアップ
+    fsWatcher.unref();
+  } catch {
+    // ディレクトリが存在しない等の場合は無視
+  }
+}
+
+// ────────────────────────────────────────────────────────────────────────────
+// ミドルウェア
+// ────────────────────────────────────────────────────────────────────────────
+
+/**
+ * /manifest.json を動的に配信するミドルウェアを返す。
+ */
+export function manifestMiddleware(opts: DevServerOptions): NextHandleFunction {
+  const absDeferred = resolve(opts.deferredDir);
+
+  return function handleManifest(
+    req: IncomingMessage,
+    res: ServerResponse,
+    next: () => void
+  ): void {
+    const url = req.url?.split('?')[0]; // クエリ文字列を除去
+    if (url !== '/manifest.json') {
+      return next();
+    }
+
+    (async () => {
+      try {
+        // キャッシュヒットならそのまま返す
+        if (manifestCache !== null) {
+          res.setHeader('Content-Type', 'application/json');
+          res.setHeader('Cache-Control', 'no-store');
+          res.end(manifestCache);
+          return;
+        }
+
+        const manifest = await buildDevManifest(
+          absDeferred,
+          opts.ignorePatterns
+        );
+        manifestCache = JSON.stringify(manifest, null, 2);
+
+        res.setHeader('Content-Type', 'application/json');
+        res.setHeader('Cache-Control', 'no-store');
+        res.end(manifestCache);
+      } catch (e) {
+        res.statusCode = 500;
+        res.setHeader('Content-Type', 'application/json');
+        res.end(JSON.stringify({ error: (e as Error).message }));
+      }
+    })();
+  };
+}
+
+/**
+ * /cdn/* を deferred/ ディレクトリから配信するミドルウェアを返す。
+ */
+export function cdnMiddleware(opts: DevServerOptions): NextHandleFunction {
+  const absDeferred = resolve(opts.deferredDir);
+
+  return function handleCdn(
+    req: IncomingMessage,
+    res: ServerResponse,
+    next: () => void
+  ): void {
+    const url = req.url;
+    if (!url || !url.startsWith('/cdn/')) {
+      return next();
+    }
+
+    // "/cdn/" プレフィックスを取り除いてデコード
+    const rawPath = url.slice('/cdn/'.length).split('?')[0];
+    let decoded: string;
+    try {
+      decoded = decodeURIComponent(rawPath);
+    } catch {
+      return next();
+    }
+
+    // パストラバーサル対策
+    if (decoded.includes('..') || decoded.startsWith('/')) {
+      res.statusCode = 400;
+      res.end('Bad Request');
+      return;
+    }
+
+    const filePath = join(absDeferred, decoded);
+
+    // absDeferred の外に出ていないか再チェック
+    if (!filePath.startsWith(absDeferred + '/') && filePath !== absDeferred) {
+      res.statusCode = 400;
+      res.end('Bad Request');
+      return;
+    }
+
+    if (!existsSync(filePath) || !statSync(filePath).isFile()) {
+      return next();
+    }
+
+    const contentType = lookup(filePath) || 'application/octet-stream';
+    res.setHeader('Content-Type', contentType);
+    res.setHeader('Cache-Control', 'no-cache');
+    res.setHeader('Access-Control-Allow-Origin', '*');
+    res.end(readFileSync(filePath));
+  };
+}
+
+// ────────────────────────────────────────────────────────────────────────────
+// Vite dev server 登録ヘルパー
+// ────────────────────────────────────────────────────────────────────────────
+
+/**
+ * ViteDevServer に static3d のミドルウェアを登録する。
+ * plugin.ts の configureServer から呼び出す。
+ */
+export function registerDevMiddlewares(
+  server: ViteDevServer,
+  opts: DevServerOptions
+): void {
+  // ファイル変更監視を開始
+  watchDeferredDir(opts.deferredDir);
+
+  // /manifest.json と /cdn/* を Vite の内部ミドルウェアより前に登録
+  server.middlewares.use(manifestMiddleware(opts));
+  server.middlewares.use(cdnMiddleware(opts));
+}

--- a/packages/deploy/src/vite/plugin.ts
+++ b/packages/deploy/src/vite/plugin.ts
@@ -1,104 +1,132 @@
+/**
+ * plugin.ts — @static3d/deploy Vite プラグイン
+ *
+ * 使い方（vite.config.ts）:
+ *
+ *   import { defineConfig } from 'vite';
+ *   import { static3d } from '@static3d/deploy/vite';
+ *
+ *   export default defineConfig({
+ *     plugins: [
+ *       static3d({
+ *         config: './static3d.config.json',  // 省略時のデフォルト
+ *       }),
+ *     ],
+ *   });
+ *
+ * dev モード:
+ *   - /manifest.json → deferred/ をスキャンして dev 用 manifest を動的生成
+ *   - /cdn/*         → deferred/ のファイルをそのまま配信（ハッシュなし）
+ *   - ファイル変更を fs.watch で検知して manifest キャッシュを自動無効化
+ *
+ * build モード:
+ *   - closeBundle フックで static3d のアセットパイプラインを自動実行
+ *   - deferred assets のハッシュ計算・gltf 書き換え・manifest 生成
+ *   - dist/pages/ と dist/cdn/ に出力
+ */
+
 import type { Plugin, ViteDevServer } from 'vite';
-import { resolve, relative } from 'node:path';
-import { readFileSync, existsSync, statSync } from 'node:fs';
-import { glob } from 'glob';
-import { lookup } from 'mime-types';
+import { resolve } from 'node:path';
 import { loadConfig, validateDeployConfig } from '../config/schema.js';
 import { build } from '../build/index.js';
+import { registerDevMiddlewares } from './devServer.js';
 
-export interface Static3dDeployOptions {
-  /** Path to static3d.config.json (default: ./static3d.config.json) */
+// ────────────────────────────────────────────────────────────────────────────
+// 公開 API
+// ────────────────────────────────────────────────────────────────────────────
+
+export interface Static3dPluginOptions {
+  /**
+   * static3d.config.json へのパス（デフォルト: './static3d.config.json'）
+   */
   config?: string;
 }
 
-export function static3dDeploy(options?: Static3dDeployOptions): Plugin {
-  let deferredDir: string;
-  let immediateDir: string;
+/**
+ * static3d Vite プラグイン。
+ *
+ * dev/build 両モードでのアセットパイプライン統合を提供する。
+ */
+export function static3d(options?: Static3dPluginOptions): Plugin {
+  let deferredDir = resolve('src/assets/deferred'); // デフォルト（フォールバック）
+  let ignorePatterns: string[] = [];
   let viteOutDir: string | undefined;
+  let isBuild = false;
 
   return {
-    name: 'static3d-deploy',
+    name: 'static3d',
 
+    // ── 設定解決フック ──────────────────────────────────────────────────────
     configResolved(resolvedConfig) {
+      isBuild = resolvedConfig.command === 'build';
       viteOutDir = resolvedConfig.build.outDir;
+
       try {
-        const config = loadConfig(options?.config);
-        const deployConfig = validateDeployConfig(config);
+        const rawConfig = loadConfig(options?.config);
+        const deployConfig = validateDeployConfig(rawConfig);
         deferredDir = resolve(deployConfig.assets.deferredDir);
-        immediateDir = resolve(deployConfig.assets.immediateDir);
+        ignorePatterns = deployConfig.assets.ignore ?? [];
       } catch {
-        // dev 時は config 不完全でもフォールバック
-        deferredDir = resolve('src/assets/deferred');
-        immediateDir = resolve('src/assets/immediate');
+        // config 不完全でも dev は動く（フォールバック値を使用）
+        // build 時は closeBundle でエラーになる
       }
     },
 
-    // 開発時: /cdn/* で deferred assets をローカル配信
+    // ── dev server ミドルウェア登録 ────────────────────────────────────────
     configureServer(server: ViteDevServer) {
-      server.middlewares.use('/cdn', (req, res, next) => {
-        if (!req.url) return next();
-        // URL デコード + パストラバーサル対策
-        const decoded = decodeURIComponent(req.url.slice(1));
-        if (decoded.includes('..')) return next();
-        const filePath = resolve(deferredDir, decoded);
-
-        if (!existsSync(filePath) || !statSync(filePath).isFile()) {
-          return next();
-        }
-
-        const contentType = lookup(filePath) || 'application/octet-stream';
-        res.setHeader('Content-Type', contentType);
-        res.setHeader('Access-Control-Allow-Origin', '*');
-        res.end(readFileSync(filePath));
+      registerDevMiddlewares(server, {
+        deferredDir,
+        ignorePatterns,
       });
 
-      // /manifest.json でローカル用簡易マニフェスト配信
-      server.middlewares.use('/manifest.json', async (_req, res) => {
-        try {
-          const files = await glob('**/*', {
-            cwd: deferredDir,
-            nodir: true,
-          });
-
-          const assets: Record<string, object> = {};
-          for (const file of files) {
-            const abs = resolve(deferredDir, file);
-            const stat = statSync(abs);
-            const key = file.replace(/\\/g, '/');
-            assets[key] = {
-              url: `/cdn/${key}`,
-              size: stat.size,
-              hash: 'dev',
-              contentType: lookup(key) || 'application/octet-stream',
-            };
-          }
-
-          const manifest = {
-            schemaVersion: 1,
-            version: 'dev',
-            buildTime: new Date().toISOString(),
-            assets,
-          };
-
-          res.setHeader('Content-Type', 'application/json');
-          res.end(JSON.stringify(manifest, null, 2));
-        } catch (e) {
-          res.statusCode = 500;
-          res.end(`{"error": "${(e as Error).message}"}`);
-        }
+      // サーバー起動完了後にログを出力
+      server.httpServer?.once('listening', () => {
+        console.log(
+          '[static3d] Dev server ready — serving /manifest.json and /cdn/*'
+        );
       });
     },
 
-    // ビルド時: Vite ビルド完了後にアセットパイプライン実行
+    // ── ビルド完了フック ───────────────────────────────────────────────────
     async closeBundle() {
+      // dev モードではビルドパイプラインを実行しない
+      if (!isBuild) return;
+
       try {
-        const config = loadConfig(options?.config);
-        const deployConfig = validateDeployConfig(config);
+        const rawConfig = loadConfig(options?.config);
+        const deployConfig = validateDeployConfig(rawConfig);
         await build(deployConfig, viteOutDir);
+
+        // ログ用: 生成された manifest から asset 数を読み取る
+        let assetCount = 0;
+        try {
+          const { readFileSync } = await import('node:fs');
+          const manifestPath = resolve(
+            deployConfig.pages?.outputDir ?? 'dist/pages',
+            'manifest.json'
+          );
+          const m = JSON.parse(readFileSync(manifestPath, 'utf-8')) as {
+            assets: Record<string, unknown>;
+          };
+          assetCount = Object.keys(m.assets).length;
+        } catch {
+          // manifest 読み取り失敗は無視（ログが不完全になるだけ）
+        }
+
+        console.log(`[static3d] Build complete — ${assetCount} assets processed`);
       } catch (e) {
-        // ビルド失敗はwarningに留める（Viteビルド自体は成功させる）
-        console.warn('[static3d-deploy] Asset pipeline skipped:', (e as Error).message);
+        // ビルド失敗は warning に留める（Vite ビルド自体は成功させる）
+        this.warn(`[static3d] Asset pipeline failed: ${(e as Error).message}`);
       }
     },
   };
 }
+
+// ────────────────────────────────────────────────────────────────────────────
+// 後方互換エイリアス（既存コードが static3dDeploy を使っている場合）
+// ────────────────────────────────────────────────────────────────────────────
+
+/** @deprecated Use `static3d` instead */
+export const static3dDeploy = static3d;
+
+export type { Static3dPluginOptions as Static3dDeployOptions };


### PR DESCRIPTION
## 概要

`@static3d/deploy` の Vite プラグインを本格実装。開発者が `vite.config.ts` に1行追加するだけで dev server と本番ビルドの両方が自動で動くようになります。

## 使い方

```ts
// vite.config.ts
import { defineConfig } from 'vite';
import { static3d } from '@static3d/deploy/vite';

export default defineConfig({
  plugins: [
    static3d({
      config: './static3d.config.json',  // 省略可
    }),
  ],
});
```

**dev モード** (`pnpm vite`)
- `/manifest.json` → deferred/ をスキャンして dev 用 manifest を動的生成
- `/cdn/*` → deferred/ のファイルをそのまま配信（ハッシュなし）
- ファイル変更を fs.watch で検知して manifest キャッシュを自動無効化
- 起動時ログ: `[static3d] Dev server ready — serving /manifest.json and /cdn/*`

**build モード** (`pnpm vite build`)
- closeBundle フックでアセットパイプラインを自動実行
- dist/pages/ と dist/cdn/ に出力
- 完了ログ: `[static3d] Build complete — 4 assets processed`

## 新規ファイル

| ファイル | 内容 |
|---|---|
| `vite/devManifest.ts` | deferred/ スキャン → dev 用 manifest 生成、.gltf 依存解析 |
| `vite/devServer.ts` | /manifest.json・/cdn/* ミドルウェア、fs.watch キャッシュ無効化 |
| `vite/plugin.ts` | `static3d()` export、configureServer + closeBundle フック |
| `src/index.ts` | パッケージ main エントリ |
| `tests/devManifest.test.ts` | 17 テスト |
| `tests/plugin.integration.test.ts` | 12 テスト |

## dev 用 manifest 仕様

```json
{
  "schemaVersion": 1,
  "version": "dev",
  "buildTime": "<現在時刻>",
  "assets": {
    "textures/albedo.png": {
      "url": "/cdn/textures/albedo.png",
      "size": 18,
      "hash": "",
      "contentType": "image/png"
    },
    "models/scene.gltf": {
      "url": "/cdn/models/scene.gltf",
      "size": 610,
      "hash": "",
      "contentType": "model/gltf+json",
      "dependencies": ["textures/albedo.png", "models/scene.bin"]
    }
  }
}
```

## テスト結果

| パッケージ | ファイル数 | テスト数 | 結果 |
|---|---|---|---|
| @static3d/deploy | 9 | 66 | ✅ 全通過 |
| @static3d/display | 3 | 25 | ✅ 全通過 |
| **合計** | **12** | **91** | ✅ |

## 制約確認

- ✅ `@static3d/display` パッケージ変更なし
- ✅ `@static3d/types` パッケージ変更なし
- ✅ 新規 npm 依存パッケージなし（connect 型はインライン定義）
- ✅ `pnpm -r build` 型エラーなし
- ✅ 既存 37 + 25 テスト全通過