### PR TITLE
feat(deploy): glTF-Transform GLB optimize pipeline (Draco+prune+dedup)

### DIFF
--- a/packages/deploy/package.json
+++ b/packages/deploy/package.json
@@ -26,7 +26,11 @@
   "dependencies": {
     "@aws-sdk/client-s3": "^3.993.0",
     "@aws-sdk/lib-storage": "^3.993.0",
+    "@gltf-transform/core": "^4.3.0",
+    "@gltf-transform/extensions": "^4.3.0",
+    "@gltf-transform/functions": "^4.3.0",
     "@static3d/types": "workspace:*",
+    "draco3dgltf": "^1.5.7",
     "glob": "^11.0.0",
     "mime-types": "^2.1.35"
   },

--- a/packages/deploy/src/build/index.ts
+++ b/packages/deploy/src/build/index.ts
@@ -1,4 +1,7 @@
 import { resolve } from 'node:path';
+import { writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
 import type { DeployConfig } from '@static3d/types';
 import { collectDeferredAssets } from './collect.js';
 import {
@@ -11,11 +14,14 @@ import {
 import { rewriteGltf } from './gltf.js';
 import { generateManifest } from './manifest.js';
 import { writeOutput } from './output.js';
+import { optimizeAsset } from './optimize.js';
 import type { HashedAsset } from './hash.js';
+import type { OptimizeConfig } from '../config/optimize-config.js';
 
 export async function build(
   config: DeployConfig,
-  viteOutputDir?: string
+  viteOutputDir?: string,
+  optimizeConfig?: OptimizeConfig
 ): Promise<void> {
   const hashLength = config.assets.hashLength ?? 8;
   const cdnBaseUrl = config.cdn.baseUrl.replace(/\/$/, '');
@@ -24,6 +30,51 @@ export async function build(
   console.log('[BUILD] Collecting assets...');
   const collected = await collectDeferredAssets(config);
   console.log(`[BUILD] Found ${collected.length} deferred assets`);
+
+  // Step 0: GLB / glTF ファイルを最適化（Draco 圧縮 / prune / dedup）
+  // hash より前に実行することで、圧縮済みバイナリのハッシュを使う。
+  // 最適化済みバッファを一時ファイルに書き出し、収集済みアセットのパスを差し替える。
+  const optimizeEnabled = optimizeConfig?.enabled === true;
+
+  if (optimizeEnabled) {
+    console.log('[BUILD] Optimizing GLB/glTF assets...');
+  }
+
+  // 最適化済みバッファを保持するマップ（key → Buffer）
+  // 一時ファイルパスのマップ（key → tempPath）
+  const optimizedPaths = new Map<string, string>();
+
+  if (optimizeEnabled) {
+    const glbGltfAssets = collected.filter(
+      (a) => a.key.endsWith('.glb') || a.key.endsWith('.gltf')
+    );
+
+    for (const asset of glbGltfAssets) {
+      const { buffer, logLine } = await optimizeAsset(asset.absolutePath, {
+        enabled: true,
+        draco: optimizeConfig?.draco !== false,
+        prune: optimizeConfig?.prune !== false,
+        dedup: optimizeConfig?.dedup !== false,
+        dracoOptions: optimizeConfig?.dracoOptions,
+      });
+
+      console.log(logLine);
+
+      if (buffer !== null) {
+        // 一時ファイルに書き出して収集済みアセットのパスを置き換える
+        const tmpPath = join(
+          tmpdir(),
+          `static3d-opt-${Date.now()}-${asset.key.replace(/\//g, '_')}`
+        );
+        writeFileSync(tmpPath, buffer);
+        optimizedPaths.set(asset.key, tmpPath);
+
+        // collected の absolutePath と size を更新
+        asset.absolutePath = tmpPath;
+        asset.size = buffer.length;
+      }
+    }
+  }
 
   // Step 1: 非 gltf ファイルのハッシュ計算
   console.log('[BUILD] Hashing non-gltf assets...');
@@ -79,9 +130,6 @@ export async function build(
   }
 
   // Step 3: バージョン生成
-  // Git が使える → "<short-sha>" （例: "abc1234"）
-  // Git 未初期化  → "content:<digest12>"（全アセットhashのダイジェスト）
-  // 同じソースセットからは Git 有無に関わらず決定論的な値が得られる。
   const allFullHashes = Array.from(hashedMap.values()).map((a) => a.hash);
   const gitSha = getGitShortSha();
   const version = gitSha ?? `content:${computeContentDigest(allFullHashes)}`;
@@ -112,7 +160,9 @@ export async function build(
     viteOutputDir
   );
 
-  console.log(`[BUILD] Done! ${allHashed.length} assets processed`);
+  const optimizedCount = optimizedPaths.size;
+  const optimizeNote = optimizedCount > 0 ? ` (${optimizedCount} optimized)` : '';
+  console.log(`[BUILD] Done! ${allHashed.length} assets processed${optimizeNote}`);
   console.log(`[BUILD]   ${pagesOutputDir}/  — Pages deployment ready`);
   console.log(`[BUILD]   dist/cdn/            — CDN deployment ready`);
 }

--- a/packages/deploy/src/build/optimize.ts
+++ b/packages/deploy/src/build/optimize.ts
@@ -1,0 +1,241 @@
+/**
+ * optimize.ts
+ *
+ * glTF-Transform を使って GLB / glTF ファイルを最適化するパイプライン。
+ *
+ * 適用する変換（すべてオプションで個別 on/off）:
+ *   1. dedup   — 重複バッファ/テクスチャ/マテリアル/アクセサ等を除去
+ *   2. prune   — 未使用ノード/マテリアル/テクスチャ等を削除
+ *   3. draco   — KHR_draco_mesh_compression でメッシュジオメトリを圧縮
+ *
+ * 圧縮前後のサイズをログ出力する:
+ *   [OPTIMIZE] scene.glb: 6.4MB → 2.1MB (-67%)
+ *
+ * ## 使い方
+ *
+ *   const result = await optimizeGlb(absolutePath, {
+ *     draco: true,
+ *     prune: true,
+ *     dedup: true,
+ *   });
+ *   // result.buffer — 最適化済み GLB バイナリ
+ *   // result.sizeBefore / result.sizeAfter
+ *
+ * ## ファイル形式対応
+ *
+ * - .glb  → NodeIO で読み込み → 変換 → GLB バッファとして書き出し
+ * - .gltf → 変換後 .gltf+.bin として返すのではなく、
+ *            GLB にまとめて返す（単一バッファで管理しやすい）
+ *
+ * ## Node.js 専用
+ *
+ * draco3dgltf / @gltf-transform は Node.js 環境のみ対応。
+ * ブラウザでは使わないこと。
+ */
+
+import { NodeIO } from '@gltf-transform/core';
+import { KHRDracoMeshCompression } from '@gltf-transform/extensions';
+import { draco, prune, dedup } from '@gltf-transform/functions';
+import { createEncoderModule } from 'draco3dgltf';
+import { readFileSync } from 'node:fs';
+import { extname, basename } from 'node:path';
+
+
+// ────────────────────────────────────────────────────────────────────────────
+// 公開型
+// ────────────────────────────────────────────────────────────────────────────
+
+/** optimize.ts への設定オプション */
+export interface OptimizeOptions {
+  /** Draco 圧縮を適用する（デフォルト: true） */
+  draco?: boolean;
+  /** 未使用リソースを prune する（デフォルト: true） */
+  prune?: boolean;
+  /** 重複データを dedup する（デフォルト: true） */
+  dedup?: boolean;
+  /**
+   * Draco 圧縮レベルのオプション（省略時はデフォルト値）
+   * encodeSpeed/decodeSpeed: 0〜10 (低=高圧縮)
+   */
+  dracoOptions?: {
+    encodeSpeed?: number;
+    decodeSpeed?: number;
+    quantizePosition?: number;
+    quantizeNormal?: number;
+    quantizeTexcoord?: number;
+    quantizeColor?: number;
+    quantizeGeneric?: number;
+  };
+}
+
+/** 最適化結果 */
+export interface OptimizeResult {
+  /** 最適化済み GLB のバイナリバッファ */
+  buffer: Buffer;
+  /** 最適化前のバイトサイズ */
+  sizeBefore: number;
+  /** 最適化後のバイトサイズ */
+  sizeAfter: number;
+  /** 削減率（0〜1、例: 0.67 = 67% 削減） */
+  reductionRatio: number;
+}
+
+// ────────────────────────────────────────────────────────────────────────────
+// ユーティリティ
+// ────────────────────────────────────────────────────────────────────────────
+
+/**
+ * バイト数を人間が読みやすい文字列に変換する。
+ * 例: 6_710_000 → "6.4MB"
+ */
+export function formatBytes(bytes: number): string {
+  if (bytes >= 1024 * 1024) {
+    return `${(bytes / 1024 / 1024).toFixed(1)}MB`;
+  }
+  if (bytes >= 1024) {
+    return `${(bytes / 1024).toFixed(1)}KB`;
+  }
+  return `${bytes}B`;
+}
+
+/**
+ * 最適化ログ文字列を生成する純粋関数。
+ * 例: "[OPTIMIZE] bakery_shop.glb: 6.4MB → 2.1MB (-67%)"
+ */
+export function formatOptimizeLog(
+  filename: string,
+  sizeBefore: number,
+  sizeAfter: number,
+  reductionRatio: number
+): string {
+  const pct = Math.round(reductionRatio * 100);
+  return `[OPTIMIZE] ${filename}: ${formatBytes(sizeBefore)} → ${formatBytes(sizeAfter)} (-${pct}%)`;
+}
+
+/**
+ * optimize がスキップされた場合のログ文字列（変換なし）。
+ */
+export function formatOptimizeSkipLog(filename: string): string {
+  return `[OPTIMIZE] ${filename}: skipped (optimize.enabled=false)`;
+}
+
+/**
+ * 削減率を計算する純粋関数。
+ */
+export function computeReductionRatio(sizeBefore: number, sizeAfter: number): number {
+  if (sizeBefore === 0) return 0;
+  return Math.max(0, (sizeBefore - sizeAfter) / sizeBefore);
+}
+
+// ────────────────────────────────────────────────────────────────────────────
+// NodeIO インスタンスファクトリ
+// ────────────────────────────────────────────────────────────────────────────
+
+/**
+ * KHRDracoMeshCompression を登録した NodeIO インスタンスを返す。
+ * テスト時に差し替えできるようファクトリ関数として切り出す。
+ */
+function createNodeIO(): NodeIO {
+  return new NodeIO().registerExtensions([KHRDracoMeshCompression]);
+}
+
+// ────────────────────────────────────────────────────────────────────────────
+// 主処理
+// ────────────────────────────────────────────────────────────────────────────
+
+/**
+ * GLB / glTF ファイルを読み込み、最適化して GLB バッファとして返す。
+ *
+ * @param absolutePath  入力ファイルの絶対パス（.glb または .gltf）
+ * @param options       最適化オプション
+ * @returns             最適化済み GLB バッファと統計情報
+ */
+export async function optimizeGlb(
+  absolutePath: string,
+  options: OptimizeOptions = {}
+): Promise<OptimizeResult> {
+  const {
+    draco: useDraco = true,
+    prune: usePrune = true,
+    dedup: useDedup = true,
+    dracoOptions = {},
+  } = options;
+
+  // 入力バッファを読む（サイズ計測のため）
+  const inputBuffer = readFileSync(absolutePath);
+  const sizeBefore = inputBuffer.length;
+
+  const io = createNodeIO();
+
+  // ファイル拡張子を判定して適切なメソッドで読み込む
+  const ext = extname(absolutePath).toLowerCase();
+  let document;
+  if (ext === '.glb') {
+    document = await io.readBinary(inputBuffer);
+  } else {
+    // .gltf はファイルパスで読む（.bin / テクスチャが同ディレクトリにある）
+    document = await io.read(absolutePath);
+  }
+
+  // 変換パイプラインを構築
+  const transforms = [];
+
+  if (useDedup) {
+    transforms.push(dedup());
+  }
+
+  if (usePrune) {
+    transforms.push(prune());
+  }
+
+  if (useDraco) {
+    // draco3dgltf の encoder モジュールを初期化し、NodeIO に登録する
+    // draco() 自体には encoder オプションはない — io.registerDependencies() 経由で渡す
+    const dracoEncoder = await createEncoderModule();
+    io.registerDependencies({ 'draco3d.encoder': dracoEncoder });
+    transforms.push(draco({ ...dracoOptions }));
+  }
+
+  // 変換を適用
+  await document.transform(...transforms);
+
+  // GLB として書き出し
+  const outputBuffer = Buffer.from(await io.writeBinary(document));
+  const sizeAfter = outputBuffer.length;
+  const reductionRatio = computeReductionRatio(sizeBefore, sizeAfter);
+
+  return { buffer: outputBuffer, sizeBefore, sizeAfter, reductionRatio };
+}
+
+/**
+ * GLB / glTF ファイルを最適化してバッファと統計ログを返す。
+ * ログは呼び出し元が console.log する。
+ *
+ * @param absolutePath  入力ファイルの絶対パス
+ * @param options       最適化オプション（enabled=false でスキップ）
+ * @returns             最適化済みバッファ（スキップ時は null）と統計ログ文字列
+ */
+export async function optimizeAsset(
+  absolutePath: string,
+  options: OptimizeOptions & { enabled?: boolean } = {}
+): Promise<{ buffer: Buffer | null; logLine: string }> {
+  const enabled = options.enabled !== false;
+  const filename = basename(absolutePath);
+
+  if (!enabled) {
+    return {
+      buffer: null,
+      logLine: formatOptimizeSkipLog(filename),
+    };
+  }
+
+  const result = await optimizeGlb(absolutePath, options);
+  const logLine = formatOptimizeLog(
+    filename,
+    result.sizeBefore,
+    result.sizeAfter,
+    result.reductionRatio
+  );
+
+  return { buffer: result.buffer, logLine };
+}

--- a/packages/deploy/src/config/optimize-config.ts
+++ b/packages/deploy/src/config/optimize-config.ts
@@ -1,0 +1,76 @@
+/**
+ * optimize-config.ts
+ *
+ * deploy パッケージローカルの最適化設定型。
+ * @static3d/types を変更せずに static3d.config.json の
+ * "optimize" フィールドを型安全に扱うための拡張型を定義する。
+ *
+ * static3d.config.json への追加例:
+ *   {
+ *     "schemaVersion": 1,
+ *     "project": "my-cake-shop",
+ *     "optimize": {
+ *       "enabled": true,
+ *       "draco": true,
+ *       "prune": true,
+ *       "dedup": true
+ *     },
+ *     "deploy": { ... }
+ *   }
+ */
+
+/** static3d.config.json の "optimize" セクション */
+export interface OptimizeConfig {
+  /** 最適化を有効にする（デフォルト: false） */
+  enabled?: boolean;
+  /** Draco 圧縮（デフォルト: true） */
+  draco?: boolean;
+  /** 未使用リソース prune（デフォルト: true） */
+  prune?: boolean;
+  /** 重複データ dedup（デフォルト: true） */
+  dedup?: boolean;
+  /**
+   * Draco 圧縮の詳細パラメーター（省略時は @gltf-transform のデフォルト）
+   * encodeSpeed / decodeSpeed: 0 (高圧縮) 〜 10 (高速)
+   */
+  dracoOptions?: {
+    encodeSpeed?: number;
+    decodeSpeed?: number;
+    quantizePosition?: number;
+    quantizeNormal?: number;
+    quantizeTexcoord?: number;
+    quantizeColor?: number;
+    quantizeGeneric?: number;
+  };
+}
+
+/**
+ * @static3d/types の Static3dConfig を "optimize" フィールドで拡張した型。
+ * loadConfig() の戻り値をこの型にキャストして使う。
+ */
+export interface Static3dConfigWithOptimize {
+  schemaVersion: 1;
+  project: string;
+  /** 最適化パイプライン設定（省略時: 最適化スキップ） */
+  optimize?: OptimizeConfig;
+  /** デプロイ設定 */
+  deploy?: Record<string, unknown>;
+  /** ディスプレイ設定 */
+  display?: Record<string, unknown>;
+  /** ドラフト設定 */
+  draft?: Record<string, unknown>;
+}
+
+/**
+ * static3d.config.json から optimize セクションを取得する。
+ * @param config  loadConfig() で読み込んだ設定オブジェクト
+ * @returns       OptimizeConfig（なければ undefined）
+ */
+export function extractOptimizeConfig(
+  config: Record<string, unknown>
+): OptimizeConfig | undefined {
+  const raw = config['optimize'];
+  if (raw === null || raw === undefined) return undefined;
+  if (typeof raw !== 'object') return undefined;
+  return raw as OptimizeConfig;
+}

--- a/packages/deploy/src/tests/optimize.test.ts
+++ b/packages/deploy/src/tests/optimize.test.ts
@@ -1,0 +1,556 @@
+/**
+ * optimize.test.ts
+ *
+ * packages/deploy/src/build/optimize.ts のユニットテスト。
+ *
+ * テスト戦略:
+ *   1. 純粋ユーティリティ関数 (formatBytes, formatOptimizeLog, computeReductionRatio)
+ *      → 引数を与えて出力を検証（副作用なし）
+ *   2. extractOptimizeConfig
+ *      → JSON オブジェクトからの抽出ロジック
+ *   3. optimizeGlb 統合テスト
+ *      → 実際の GLB バイナリを生成して最適化パイプラインを実行
+ *      → 出力が GLB (binary glTF, magic 0x46546C67) であることを確認
+ *      → enable=false / draco=false / prune only など各フラグをテスト
+ *   4. optimizeAsset
+ *      → enabled=false のとき null + skip ログを返すことを確認
+ *
+ * NOTE: @gltf-transform は ESM only。vitest は ESM モードで動作するため問題なし。
+ */
+
+import { describe, it, expect } from 'vitest';
+import { mkdirSync, writeFileSync, rmSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+
+// ────────────────────────────────────────────────────────────────────────────
+// 最小限の有効な GLB ファイルを生成するヘルパー
+// ────────────────────────────────────────────────────────────────────────────
+
+/**
+ * 最小限の GLB バイナリを Buffer として生成する。
+ *
+ * GLB フォーマット:
+ *   [12 byte header][JSON chunk][BIN chunk(任意)]
+ *
+ * header:
+ *   magic    = 0x46546C67 ("glTF", little-endian)
+ *   version  = 2
+ *   length   = 全体バイト数
+ *
+ * JSON chunk:
+ *   chunkLength = JSON バイト数（4 の倍数に padding）
+ *   chunkType   = 0x4E4F534A ("JSON")
+ *   chunkData   = UTF-8 JSON + space padding
+ */
+function makeMinimalGlb(extraMeshData?: Uint8Array): Buffer {
+  // 最小限の glTF JSON（ジオメトリなし）
+  const gltfJson = JSON.stringify({
+    asset: { version: '2.0', generator: 'static3d test' },
+    scene: 0,
+    scenes: [{ nodes: [0] }],
+    nodes: [{ name: 'RootNode' }],
+    // メッシュがないと Draco は何もしない — OK
+  });
+
+  // JSON を 4 バイト境界に align
+  const jsonBytes = Buffer.from(gltfJson, 'utf-8');
+  const jsonPadded = Math.ceil(jsonBytes.length / 4) * 4;
+  const jsonChunk = Buffer.alloc(jsonPadded, 0x20); // space padding
+  jsonBytes.copy(jsonChunk);
+
+  // GLB header (12 bytes) + JSON chunk header (8 bytes) + JSON data
+  const totalLength = 12 + 8 + jsonPadded;
+  const buf = Buffer.alloc(totalLength);
+  let offset = 0;
+
+  // Header
+  buf.writeUInt32LE(0x46546C67, offset); offset += 4; // magic "glTF"
+  buf.writeUInt32LE(2, offset);          offset += 4; // version
+  buf.writeUInt32LE(totalLength, offset); offset += 4; // length
+
+  // JSON chunk
+  buf.writeUInt32LE(jsonPadded, offset); offset += 4; // chunkLength
+  buf.writeUInt32LE(0x4E4F534A, offset); offset += 4; // chunkType "JSON"
+  jsonChunk.copy(buf, offset);
+
+  return buf;
+}
+
+/**
+ * 単純な三角形メッシュを含む GLB を生成する（Draco 圧縮のテスト用）。
+ * 頂点 3 個（float32 × 3）、インデックス 3 個（uint16）を持つ最小 mesh。
+ */
+function makeTriangleGlb(): Buffer {
+  // BIN バッファ: 頂点データ + インデックスデータ
+  const positions = new Float32Array([
+    0.0, 0.0, 0.0,   // v0
+    1.0, 0.0, 0.0,   // v1
+    0.0, 1.0, 0.0,   // v2
+  ]);
+  const indices = new Uint16Array([0, 1, 2]);
+
+  // 4 バイト境界に align
+  const posBytes = Buffer.from(positions.buffer);
+  const idxBytes = Buffer.from(indices.buffer);
+  const idxOffset = posBytes.length; // positions は 36 bytes → already aligned
+
+  const binBuffer = Buffer.concat([posBytes, idxBytes]);
+  // BIN を 4 バイト境界に padding
+  const binPadded = Math.ceil(binBuffer.length / 4) * 4;
+  const binChunkData = Buffer.alloc(binPadded, 0);
+  binBuffer.copy(binChunkData);
+
+  const gltfJson = JSON.stringify({
+    asset: { version: '2.0', generator: 'static3d test' },
+    scene: 0,
+    scenes: [{ nodes: [0] }],
+    nodes: [{ mesh: 0 }],
+    meshes: [{
+      primitives: [{
+        attributes: { POSITION: 0 },
+        indices: 1,
+        mode: 4,  // TRIANGLES
+      }],
+    }],
+    accessors: [
+      {
+        bufferView: 0,
+        componentType: 5126,  // FLOAT
+        count: 3,
+        type: 'VEC3',
+        byteOffset: 0,
+        max: [1.0, 1.0, 0.0],
+        min: [0.0, 0.0, 0.0],
+      },
+      {
+        bufferView: 1,
+        componentType: 5123,  // UNSIGNED_SHORT
+        count: 3,
+        type: 'SCALAR',
+        byteOffset: 0,
+      },
+    ],
+    bufferViews: [
+      { buffer: 0, byteOffset: 0, byteLength: posBytes.length },
+      { buffer: 0, byteOffset: idxOffset, byteLength: idxBytes.length },
+    ],
+    buffers: [{ byteLength: binBuffer.length }],
+  });
+
+  const jsonBytes = Buffer.from(gltfJson, 'utf-8');
+  const jsonPadded = Math.ceil(jsonBytes.length / 4) * 4;
+  const jsonChunkData = Buffer.alloc(jsonPadded, 0x20);
+  jsonBytes.copy(jsonChunkData);
+
+  const totalLength = 12 + 8 + jsonPadded + 8 + binPadded;
+  const glb = Buffer.alloc(totalLength);
+  let off = 0;
+
+  // Header
+  glb.writeUInt32LE(0x46546C67, off); off += 4;
+  glb.writeUInt32LE(2, off);          off += 4;
+  glb.writeUInt32LE(totalLength, off); off += 4;
+
+  // JSON chunk
+  glb.writeUInt32LE(jsonPadded, off);   off += 4;
+  glb.writeUInt32LE(0x4E4F534A, off);   off += 4;
+  jsonChunkData.copy(glb, off);          off += jsonPadded;
+
+  // BIN chunk
+  glb.writeUInt32LE(binPadded, off);    off += 4;
+  glb.writeUInt32LE(0x004E4942, off);   off += 4; // "BIN\0"
+  binChunkData.copy(glb, off);
+
+  return glb;
+}
+
+/** GLB magic bytes の検証 */
+function isGlbMagic(buf: Buffer): boolean {
+  return buf.length >= 4 && buf.readUInt32LE(0) === 0x46546C67;
+}
+
+// ────────────────────────────────────────────────────────────────────────────
+// 1. formatBytes
+// ────────────────────────────────────────────────────────────────────────────
+
+describe('formatBytes', () => {
+  it('formats bytes as B', async () => {
+    const { formatBytes } = await import('../build/optimize.js');
+    expect(formatBytes(512)).toBe('512B');
+  });
+
+  it('formats kilobytes as KB', async () => {
+    const { formatBytes } = await import('../build/optimize.js');
+    expect(formatBytes(2048)).toBe('2.0KB');
+  });
+
+  it('formats megabytes as MB', async () => {
+    const { formatBytes } = await import('../build/optimize.js');
+    expect(formatBytes(6_700_000)).toBe('6.4MB');
+  });
+
+  it('formats 1MB boundary', async () => {
+    const { formatBytes } = await import('../build/optimize.js');
+    expect(formatBytes(1024 * 1024)).toBe('1.0MB');
+  });
+
+  it('formats 0 as 0B', async () => {
+    const { formatBytes } = await import('../build/optimize.js');
+    expect(formatBytes(0)).toBe('0B');
+  });
+
+  it('formats 1023 as KB boundary', async () => {
+    const { formatBytes } = await import('../build/optimize.js');
+    // 1023 < 1024 → bytes
+    expect(formatBytes(1023)).toBe('1023B');
+  });
+
+  it('formats large file correctly', async () => {
+    const { formatBytes } = await import('../build/optimize.js');
+    expect(formatBytes(2_100_000)).toBe('2.0MB');
+  });
+});
+
+// ────────────────────────────────────────────────────────────────────────────
+// 2. computeReductionRatio
+// ────────────────────────────────────────────────────────────────────────────
+
+describe('computeReductionRatio', () => {
+  it('returns 0 when sizeBefore=0', async () => {
+    const { computeReductionRatio } = await import('../build/optimize.js');
+    expect(computeReductionRatio(0, 0)).toBe(0);
+  });
+
+  it('computes 67% reduction correctly', async () => {
+    const { computeReductionRatio } = await import('../build/optimize.js');
+    const ratio = computeReductionRatio(3_000_000, 990_000);
+    expect(ratio).toBeCloseTo(0.67, 1);
+  });
+
+  it('returns 0 when sizeAfter >= sizeBefore', async () => {
+    const { computeReductionRatio } = await import('../build/optimize.js');
+    expect(computeReductionRatio(100, 200)).toBe(0);
+  });
+
+  it('computes 50% reduction', async () => {
+    const { computeReductionRatio } = await import('../build/optimize.js');
+    expect(computeReductionRatio(1000, 500)).toBeCloseTo(0.5, 5);
+  });
+
+  it('computes 100% reduction (empty output)', async () => {
+    const { computeReductionRatio } = await import('../build/optimize.js');
+    expect(computeReductionRatio(1000, 0)).toBe(1);
+  });
+});
+
+// ────────────────────────────────────────────────────────────────────────────
+// 3. formatOptimizeLog
+// ────────────────────────────────────────────────────────────────────────────
+
+describe('formatOptimizeLog', () => {
+  it('produces the expected log format', async () => {
+    const { formatOptimizeLog } = await import('../build/optimize.js');
+    const log = formatOptimizeLog('bakery_shop.glb', 6_700_000, 2_100_000, 0.6865);
+    expect(log).toBe('[OPTIMIZE] bakery_shop.glb: 6.4MB → 2.0MB (-69%)');
+  });
+
+  it('includes [OPTIMIZE] prefix', async () => {
+    const { formatOptimizeLog } = await import('../build/optimize.js');
+    const log = formatOptimizeLog('scene.glb', 1024, 512, 0.5);
+    expect(log.startsWith('[OPTIMIZE]')).toBe(true);
+  });
+
+  it('includes the filename', async () => {
+    const { formatOptimizeLog } = await import('../build/optimize.js');
+    const log = formatOptimizeLog('my_model.glb', 2048, 1024, 0.5);
+    expect(log).toContain('my_model.glb');
+  });
+
+  it('includes percentage', async () => {
+    const { formatOptimizeLog } = await import('../build/optimize.js');
+    const log = formatOptimizeLog('x.glb', 1000, 330, 0.67);
+    expect(log).toContain('-67%');
+  });
+
+  it('includes arrow →', async () => {
+    const { formatOptimizeLog } = await import('../build/optimize.js');
+    const log = formatOptimizeLog('x.glb', 1000, 500, 0.5);
+    expect(log).toContain('→');
+  });
+
+  it('shows before and after sizes', async () => {
+    const { formatOptimizeLog, formatBytes } = await import('../build/optimize.js');
+    const before = 5_000_000;
+    const after = 1_500_000;
+    const ratio = (before - after) / before;
+    const log = formatOptimizeLog('test.glb', before, after, ratio);
+    expect(log).toContain(formatBytes(before));
+    expect(log).toContain(formatBytes(after));
+  });
+});
+
+// ────────────────────────────────────────────────────────────────────────────
+// 4. formatOptimizeSkipLog
+// ────────────────────────────────────────────────────────────────────────────
+
+describe('formatOptimizeSkipLog', () => {
+  it('includes [OPTIMIZE] prefix', async () => {
+    const { formatOptimizeSkipLog } = await import('../build/optimize.js');
+    expect(formatOptimizeSkipLog('scene.glb').startsWith('[OPTIMIZE]')).toBe(true);
+  });
+
+  it('includes filename', async () => {
+    const { formatOptimizeSkipLog } = await import('../build/optimize.js');
+    expect(formatOptimizeSkipLog('model.glb')).toContain('model.glb');
+  });
+
+  it('includes "skipped"', async () => {
+    const { formatOptimizeSkipLog } = await import('../build/optimize.js');
+    expect(formatOptimizeSkipLog('x.glb')).toContain('skipped');
+  });
+});
+
+// ────────────────────────────────────────────────────────────────────────────
+// 5. extractOptimizeConfig
+// ────────────────────────────────────────────────────────────────────────────
+
+describe('extractOptimizeConfig', () => {
+  it('extracts optimize config from full config object', async () => {
+    const { extractOptimizeConfig } = await import('../config/optimize-config.js');
+    const config = {
+      schemaVersion: 1,
+      project: 'test',
+      optimize: { enabled: true, draco: true, prune: true, dedup: false },
+    };
+    const opt = extractOptimizeConfig(config);
+    expect(opt).toBeDefined();
+    expect(opt!.enabled).toBe(true);
+    expect(opt!.draco).toBe(true);
+    expect(opt!.dedup).toBe(false);
+  });
+
+  it('returns undefined when optimize is missing', async () => {
+    const { extractOptimizeConfig } = await import('../config/optimize-config.js');
+    expect(extractOptimizeConfig({ schemaVersion: 1, project: 'x' })).toBeUndefined();
+  });
+
+  it('returns undefined when optimize is null', async () => {
+    const { extractOptimizeConfig } = await import('../config/optimize-config.js');
+    expect(extractOptimizeConfig({ optimize: null })).toBeUndefined();
+  });
+
+  it('returns undefined when optimize is a non-object', async () => {
+    const { extractOptimizeConfig } = await import('../config/optimize-config.js');
+    expect(extractOptimizeConfig({ optimize: 'yes' })).toBeUndefined();
+  });
+
+  it('handles partial optimize config (only enabled)', async () => {
+    const { extractOptimizeConfig } = await import('../config/optimize-config.js');
+    const config = { optimize: { enabled: false } };
+    const opt = extractOptimizeConfig(config);
+    expect(opt).toBeDefined();
+    expect(opt!.enabled).toBe(false);
+    expect(opt!.draco).toBeUndefined();
+  });
+
+  it('preserves dracoOptions', async () => {
+    const { extractOptimizeConfig } = await import('../config/optimize-config.js');
+    const config = {
+      optimize: {
+        enabled: true,
+        draco: true,
+        dracoOptions: { encodeSpeed: 3, decodeSpeed: 3 },
+      },
+    };
+    const opt = extractOptimizeConfig(config);
+    expect(opt!.dracoOptions?.encodeSpeed).toBe(3);
+  });
+});
+
+// ────────────────────────────────────────────────────────────────────────────
+// 6. optimizeAsset — enabled=false (skip path, no GLB needed)
+// ────────────────────────────────────────────────────────────────────────────
+
+describe('optimizeAsset — skip mode', () => {
+  it('returns null buffer and skip log when enabled=false', async () => {
+    const { optimizeAsset } = await import('../build/optimize.js');
+    // enabled=false なので実際のファイルは不要
+    const { buffer, logLine } = await optimizeAsset('/nonexistent/fake.glb', {
+      enabled: false,
+    });
+    expect(buffer).toBeNull();
+    expect(logLine).toContain('[OPTIMIZE]');
+    expect(logLine).toContain('skipped');
+    expect(logLine).toContain('fake.glb');
+  });
+
+  it('returns skip log with correct filename', async () => {
+    const { optimizeAsset } = await import('../build/optimize.js');
+    const { logLine } = await optimizeAsset('/path/to/my_scene.glb', {
+      enabled: false,
+    });
+    expect(logLine).toContain('my_scene.glb');
+  });
+});
+
+// ────────────────────────────────────────────────────────────────────────────
+// 7. optimizeGlb — integration (minimal GLB)
+// ────────────────────────────────────────────────────────────────────────────
+
+describe('optimizeGlb — minimal GLB (no mesh)', () => {
+  let tmpDir: string;
+
+  // テスト用一時ディレクトリをセットアップ
+  const setup = () => {
+    tmpDir = join(tmpdir(), `static3d-opt-test-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+    mkdirSync(tmpDir, { recursive: true });
+  };
+
+  const cleanup = () => {
+    if (tmpDir) rmSync(tmpDir, { recursive: true, force: true });
+  };
+
+  it('outputs a valid GLB (magic bytes = glTF)', async () => {
+    setup();
+    try {
+      const { optimizeGlb } = await import('../build/optimize.js');
+      const glbPath = join(tmpDir, 'minimal.glb');
+      writeFileSync(glbPath, makeMinimalGlb());
+
+      const result = await optimizeGlb(glbPath, { draco: false, prune: true, dedup: true });
+      expect(isGlbMagic(result.buffer)).toBe(true);
+    } finally {
+      cleanup();
+    }
+  }, 30_000);
+
+  it('OptimizeResult has sizeBefore and sizeAfter', async () => {
+    setup();
+    try {
+      const { optimizeGlb } = await import('../build/optimize.js');
+      const glbPath = join(tmpDir, 'minimal.glb');
+      const inputBuf = makeMinimalGlb();
+      writeFileSync(glbPath, inputBuf);
+
+      const result = await optimizeGlb(glbPath, { draco: false, prune: true, dedup: true });
+      expect(result.sizeBefore).toBe(inputBuf.length);
+      expect(result.sizeAfter).toBeGreaterThan(0);
+    } finally {
+      cleanup();
+    }
+  }, 30_000);
+
+  it('reductionRatio is a number between 0 and 1', async () => {
+    setup();
+    try {
+      const { optimizeGlb } = await import('../build/optimize.js');
+      const glbPath = join(tmpDir, 'minimal.glb');
+      writeFileSync(glbPath, makeMinimalGlb());
+
+      const result = await optimizeGlb(glbPath, { draco: false, prune: true, dedup: true });
+      expect(result.reductionRatio).toBeGreaterThanOrEqual(0);
+      expect(result.reductionRatio).toBeLessThanOrEqual(1);
+    } finally {
+      cleanup();
+    }
+  }, 30_000);
+
+  it('prune-only mode still produces valid GLB', async () => {
+    setup();
+    try {
+      const { optimizeGlb } = await import('../build/optimize.js');
+      const glbPath = join(tmpDir, 'prune-only.glb');
+      writeFileSync(glbPath, makeMinimalGlb());
+
+      const result = await optimizeGlb(glbPath, { draco: false, prune: true, dedup: false });
+      expect(isGlbMagic(result.buffer)).toBe(true);
+    } finally {
+      cleanup();
+    }
+  }, 30_000);
+
+  it('dedup-only mode still produces valid GLB', async () => {
+    setup();
+    try {
+      const { optimizeGlb } = await import('../build/optimize.js');
+      const glbPath = join(tmpDir, 'dedup-only.glb');
+      writeFileSync(glbPath, makeMinimalGlb());
+
+      const result = await optimizeGlb(glbPath, { draco: false, prune: false, dedup: true });
+      expect(isGlbMagic(result.buffer)).toBe(true);
+    } finally {
+      cleanup();
+    }
+  }, 30_000);
+});
+
+// ────────────────────────────────────────────────────────────────────────────
+// 8. optimizeGlb — integration (triangle mesh with Draco)
+// ────────────────────────────────────────────────────────────────────────────
+
+describe('optimizeGlb — triangle mesh with Draco', () => {
+  let tmpDir: string;
+
+  const setup = () => {
+    tmpDir = join(tmpdir(), `static3d-draco-test-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+    mkdirSync(tmpDir, { recursive: true });
+  };
+
+  const cleanup = () => {
+    if (tmpDir) rmSync(tmpDir, { recursive: true, force: true });
+  };
+
+  it('Draco compression produces valid GLB', async () => {
+    setup();
+    try {
+      const { optimizeGlb } = await import('../build/optimize.js');
+      const glbPath = join(tmpDir, 'triangle.glb');
+      writeFileSync(glbPath, makeTriangleGlb());
+
+      const result = await optimizeGlb(glbPath, { draco: true, prune: true, dedup: true });
+      expect(isGlbMagic(result.buffer)).toBe(true);
+    } finally {
+      cleanup();
+    }
+  }, 60_000);
+
+  it('Draco compression sizeBefore is the original file size', async () => {
+    setup();
+    try {
+      const { optimizeGlb } = await import('../build/optimize.js');
+      const glbPath = join(tmpDir, 'triangle.glb');
+      const input = makeTriangleGlb();
+      writeFileSync(glbPath, input);
+
+      const result = await optimizeGlb(glbPath, { draco: true, prune: true, dedup: true });
+      expect(result.sizeBefore).toBe(input.length);
+    } finally {
+      cleanup();
+    }
+  }, 60_000);
+
+  it('optimizeAsset returns buffer and log for GLB with Draco', async () => {
+    setup();
+    try {
+      const { optimizeAsset } = await import('../build/optimize.js');
+      const glbPath = join(tmpDir, 'scene.glb');
+      writeFileSync(glbPath, makeTriangleGlb());
+
+      const { buffer, logLine } = await optimizeAsset(glbPath, {
+        enabled: true,
+        draco: true,
+        prune: true,
+        dedup: true,
+      });
+
+      expect(buffer).not.toBeNull();
+      expect(isGlbMagic(buffer!)).toBe(true);
+      expect(logLine).toContain('[OPTIMIZE]');
+      expect(logLine).toContain('scene.glb');
+      expect(logLine).toContain('→');
+    } finally {
+      cleanup();
+    }
+  }, 60_000);
+});

--- a/packages/deploy/src/types/draco3dgltf.d.ts
+++ b/packages/deploy/src/types/draco3dgltf.d.ts
@@ -1,0 +1,25 @@
+/**
+ * Type declaration for draco3dgltf (no official @types package).
+ * draco3dgltf exports a default object with createEncoderModule and
+ * createDecoderModule factory functions.
+ */
+
+declare module 'draco3dgltf' {
+  /** Draco encoder/decoder module instance (opaque to gltf-transform) */
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  export type DracoModule = Record<string, any>;
+
+  /**
+   * Creates and resolves a Draco encoder WebAssembly module.
+   * Pass the resolved value to NodeIO.registerDependencies as
+   * `{ 'draco3d.encoder': module }`.
+   */
+  export function createEncoderModule(): Promise<DracoModule>;
+
+  /**
+   * Creates and resolves a Draco decoder WebAssembly module.
+   * Pass the resolved value to NodeIO.registerDependencies as
+   * `{ 'draco3d.decoder': module }`.
+   */
+  export function createDecoderModule(): Promise<DracoModule>;
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -16,9 +16,21 @@ importers:
       '@aws-sdk/lib-storage':
         specifier: ^3.993.0
         version: 3.993.0(@aws-sdk/client-s3@3.993.0)
+      '@gltf-transform/core':
+        specifier: ^4.3.0
+        version: 4.3.0
+      '@gltf-transform/extensions':
+        specifier: ^4.3.0
+        version: 4.3.0
+      '@gltf-transform/functions':
+        specifier: ^4.3.0
+        version: 4.3.0
       '@static3d/types':
         specifier: workspace:*
         version: link:../types
+      draco3dgltf:
+        specifier: ^1.5.7
+        version: 1.5.7
       glob:
         specifier: ^11.0.0
         version: 11.1.0
@@ -259,6 +271,9 @@ packages:
   '@babel/runtime@7.28.6':
     resolution: {integrity: sha512-05WQkdpL9COIMz4LjTxGpPNCdlpyimKppYNoJ5Di5EUObifl8t4tuLuUBBZEpoLYOmfvIWrsp9fCl0HoPRVTdA==}
     engines: {node: '>=6.9.0'}
+
+  '@emnapi/runtime@1.8.1':
+    resolution: {integrity: sha512-mehfKSMWjjNol8659Z8KxEMrdSJDDot5SXMq00dM8BN4o+CLNXQ0xH2V7EchNHV4RmbZLmmPdEaXZc5H2FXmDg==}
 
   '@esbuild/aix-ppc64@0.21.5':
     resolution: {integrity: sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ==}
@@ -551,6 +566,152 @@ packages:
   '@esbuild/win32-x64@0.25.12':
     resolution: {integrity: sha512-alJC0uCZpTFrSL0CCDjcgleBXPnCrEAhTBILpeAp7M/OFgoqtAetfBzX0xM00MUsVVPpVjlPuMbREqnZCXaTnA==}
     engines: {node: '>=18'}
+    cpu: [x64]
+    os: [win32]
+
+  '@gltf-transform/core@4.3.0':
+    resolution: {integrity: sha512-ZeaQfszGJ9LYwELszu45CuDQCsE26lJNNe36FVmN8xclaT6WDdCj7fwGpQXo0/l/YgAVAHX+uO7YNBW75/SRYw==}
+
+  '@gltf-transform/extensions@4.3.0':
+    resolution: {integrity: sha512-XDAjQPYVMHa/VDpSbfCBwI+/1muwRJCaXhUpLgnUzAjn0D//PgvIAcbNm1EwBl3LIWBSwjDUCn2LiMAjp+aXVw==}
+
+  '@gltf-transform/functions@4.3.0':
+    resolution: {integrity: sha512-FZggHVgt3DHOezgESBrf2vDzuD2FYQYaNT2sT/aP316SIwhuiIwby3z7rhV9joDvWqqUaPkf1UmkjlOaY9riSQ==}
+
+  '@img/colour@1.0.0':
+    resolution: {integrity: sha512-A5P/LfWGFSl6nsckYtjw9da+19jB8hkJ6ACTGcDfEJ0aE+l2n2El7dsVM7UVHZQ9s2lmYMWlrS21YLy2IR1LUw==}
+    engines: {node: '>=18'}
+
+  '@img/sharp-darwin-arm64@0.34.5':
+    resolution: {integrity: sha512-imtQ3WMJXbMY4fxb/Ndp6HBTNVtWCUI0WdobyheGf5+ad6xX8VIDO8u2xE4qc/fr08CKG/7dDseFtn6M6g/r3w==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@img/sharp-darwin-x64@0.34.5':
+    resolution: {integrity: sha512-YNEFAF/4KQ/PeW0N+r+aVVsoIY0/qxxikF2SWdp+NRkmMB7y9LBZAVqQ4yhGCm/H3H270OSykqmQMKLBhBJDEw==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [x64]
+    os: [darwin]
+
+  '@img/sharp-libvips-darwin-arm64@1.2.4':
+    resolution: {integrity: sha512-zqjjo7RatFfFoP0MkQ51jfuFZBnVE2pRiaydKJ1G/rHZvnsrHAOcQALIi9sA5co5xenQdTugCvtb1cuf78Vf4g==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@img/sharp-libvips-darwin-x64@1.2.4':
+    resolution: {integrity: sha512-1IOd5xfVhlGwX+zXv2N93k0yMONvUlANylbJw1eTah8K/Jtpi15KC+WSiaX/nBmbm2HxRM1gZ0nSdjSsrZbGKg==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@img/sharp-libvips-linux-arm64@1.2.4':
+    resolution: {integrity: sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@img/sharp-libvips-linux-arm@1.2.4':
+    resolution: {integrity: sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A==}
+    cpu: [arm]
+    os: [linux]
+
+  '@img/sharp-libvips-linux-ppc64@1.2.4':
+    resolution: {integrity: sha512-FMuvGijLDYG6lW+b/UvyilUWu5Ayu+3r2d1S8notiGCIyYU/76eig1UfMmkZ7vwgOrzKzlQbFSuQfgm7GYUPpA==}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@img/sharp-libvips-linux-riscv64@1.2.4':
+    resolution: {integrity: sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA==}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@img/sharp-libvips-linux-s390x@1.2.4':
+    resolution: {integrity: sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ==}
+    cpu: [s390x]
+    os: [linux]
+
+  '@img/sharp-libvips-linux-x64@1.2.4':
+    resolution: {integrity: sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==}
+    cpu: [x64]
+    os: [linux]
+
+  '@img/sharp-libvips-linuxmusl-arm64@1.2.4':
+    resolution: {integrity: sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@img/sharp-libvips-linuxmusl-x64@1.2.4':
+    resolution: {integrity: sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg==}
+    cpu: [x64]
+    os: [linux]
+
+  '@img/sharp-linux-arm64@0.34.5':
+    resolution: {integrity: sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [arm64]
+    os: [linux]
+
+  '@img/sharp-linux-arm@0.34.5':
+    resolution: {integrity: sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [arm]
+    os: [linux]
+
+  '@img/sharp-linux-ppc64@0.34.5':
+    resolution: {integrity: sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@img/sharp-linux-riscv64@0.34.5':
+    resolution: {integrity: sha512-51gJuLPTKa7piYPaVs8GmByo7/U7/7TZOq+cnXJIHZKavIRHAP77e3N2HEl3dgiqdD/w0yUfiJnII77PuDDFdw==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@img/sharp-linux-s390x@0.34.5':
+    resolution: {integrity: sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [s390x]
+    os: [linux]
+
+  '@img/sharp-linux-x64@0.34.5':
+    resolution: {integrity: sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [x64]
+    os: [linux]
+
+  '@img/sharp-linuxmusl-arm64@0.34.5':
+    resolution: {integrity: sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [arm64]
+    os: [linux]
+
+  '@img/sharp-linuxmusl-x64@0.34.5':
+    resolution: {integrity: sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [x64]
+    os: [linux]
+
+  '@img/sharp-wasm32@0.34.5':
+    resolution: {integrity: sha512-OdWTEiVkY2PHwqkbBI8frFxQQFekHaSSkUIJkwzclWZe64O1X4UlUjqqqLaPbUpMOQk6FBu/HtlGXNblIs0huw==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [wasm32]
+
+  '@img/sharp-win32-arm64@0.34.5':
+    resolution: {integrity: sha512-WQ3AgWCWYSb2yt+IG8mnC6Jdk9Whs7O0gxphblsLvdhSpSTtmu69ZG1Gkb6NuvxsNACwiPV6cNSZNzt0KPsw7g==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [arm64]
+    os: [win32]
+
+  '@img/sharp-win32-ia32@0.34.5':
+    resolution: {integrity: sha512-FV9m/7NmeCmSHDD5j4+4pNI8Cp3aW+JvLoXcTUo0IqyjSfAZJ8dIUmijx1qaJsIiU+Hosw6xM5KijAWRJCSgNg==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [ia32]
+    os: [win32]
+
+  '@img/sharp-win32-x64@0.34.5':
+    resolution: {integrity: sha512-+29YMsqY2/9eFEiW93eqWnuLcWcufowXewwSNIT6UwZdUUCrM3oFjMWH/Z6/TMmb4hlFenmfAVbpWeup2jryCw==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [win32]
 
@@ -986,6 +1147,9 @@ packages:
   '@types/mime-types@2.1.4':
     resolution: {integrity: sha512-lfU4b34HOri+kAY5UheuFMWPDOI+OPceBSHZKp69gEyTL/mmJ4cnU6Y/rlme3UL3GyOn6Y42hyIEw0/q8sWx5w==}
 
+  '@types/ndarray@1.0.14':
+    resolution: {integrity: sha512-oANmFZMnFQvb219SSBIhI1Ih/r4CvHDOzkWyJS/XRqkMrGH5/kaPSA1hQhdIBzouaE+5KpE/f5ylI9cujmckQg==}
+
   '@types/node@22.19.11':
     resolution: {integrity: sha512-BH7YwL6rA93ReqeQS1c4bsPpcfOmJasG+Fkr6Y59q83f9M1WcBRHR2vM+P9eOisYRcN3ujQoiZY8uk5W+1WL8w==}
 
@@ -1111,6 +1275,9 @@ packages:
   csstype@3.2.3:
     resolution: {integrity: sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==}
 
+  cwise-compiler@1.1.3:
+    resolution: {integrity: sha512-WXlK/m+Di8DMMcCjcWr4i+XzcQra9eCdXIJrgh4TUgh0pIS/yJduLxS9JgefsHJ/YVLdgPtXm9r62W92MvanEQ==}
+
   debug@4.4.3:
     resolution: {integrity: sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==}
     engines: {node: '>=6.0'}
@@ -1127,8 +1294,15 @@ packages:
   detect-gpu@5.0.70:
     resolution: {integrity: sha512-bqerEP1Ese6nt3rFkwPnGbsUF9a4q+gMmpTVVOEzoCyeCc+y7/RvJnQZJx1JwhgQI5Ntg0Kgat8Uu7XpBqnz1w==}
 
+  detect-libc@2.1.2:
+    resolution: {integrity: sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==}
+    engines: {node: '>=8'}
+
   draco3d@1.5.7:
     resolution: {integrity: sha512-m6WCKt/erDXcw+70IJXnG7M3awwQPAsZvJGX5zY7beBqpELw6RDGkYVU0W43AFxye4pDZ5i2Lbyc/NNGqwjUVQ==}
+
+  draco3dgltf@1.5.7:
+    resolution: {integrity: sha512-LeqcpmoHIyYUi0z70/H3tMkGj8QhqVxq6FJGPjlzR24BNkQ6jyMheMvFKJBI0dzGZrEOUyQEmZ8axM1xRrbRiw==}
 
   entities@7.0.1:
     resolution: {integrity: sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==}
@@ -1211,6 +1385,12 @@ packages:
   inherits@2.0.4:
     resolution: {integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==}
 
+  iota-array@1.0.0:
+    resolution: {integrity: sha512-pZ2xT+LOHckCatGQ3DcG/a+QuEqvoxqkiL7tvE8nn3uuu+f6i1TtpB5/FtWFbxUuVr5PZCx8KskuGatbJDXOWA==}
+
+  is-buffer@1.1.6:
+    resolution: {integrity: sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==}
+
   is-promise@2.2.2:
     resolution: {integrity: sha512-+lP4/6lKUBfQjZ2pdxThZvLUAafmZb8OAxFb8XXtiQmS35INgr85hdOGoEs124ez1FCnZJt6jau/T+alh58QFQ==}
 
@@ -1228,6 +1408,9 @@ packages:
 
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
+
+  ktx-parse@1.1.0:
+    resolution: {integrity: sha512-mKp3y+FaYgR7mXWAbyyzpa/r1zDWeaunH+INJO4fou3hb45XuNSwar+7llrRyvpMWafxSIi99RNFJ05MHedaJQ==}
 
   lie@3.3.0:
     resolution: {integrity: sha512-UaiMJzeWRlEujzAuw5LokY1L5ecNQYZKfmyZ9L7wDHb/p5etKaxXhohBcrw0EYby+G/NA52vRSN4N39dxHAIwQ==}
@@ -1284,6 +1467,18 @@ packages:
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
+  ndarray-lanczos@0.3.0:
+    resolution: {integrity: sha512-5kBmmG3Zvyj77qxIAC4QFLKuYdDIBJwCG+DukT6jQHNa1Ft74/hPH1z5mbQXeHBt8yvGPBGVrr3wEOdJPYYZYg==}
+
+  ndarray-ops@1.2.2:
+    resolution: {integrity: sha512-BppWAFRjMYF7N/r6Ie51q6D4fs0iiGmeXIACKY66fLpnwIui3Wc3CXiD/30mgLbDjPpSLrsqcp3Z62+IcHZsDw==}
+
+  ndarray-pixels@5.0.1:
+    resolution: {integrity: sha512-IBtrpefpqlI8SPDCGjXk4v5NV5z7r3JSuCbfuEEXaM0vrOJtNGgYUa4C3Lt5H+qWdYF4BCPVFsnXhNC7QvZwkw==}
+
+  ndarray@1.0.19:
+    resolution: {integrity: sha512-B4JHA4vdyZU30ELBw3g7/p9bZupyew5a7tX1Y/gGeF2hafrPaQZhgrGQfsvgfYbgdFZjYwuEcnaobeM/WMW+HQ==}
+
   object-assign@4.1.1:
     resolution: {integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==}
     engines: {node: '>=0.10.0'}
@@ -1325,6 +1520,9 @@ packages:
 
   prop-types@15.8.1:
     resolution: {integrity: sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==}
+
+  property-graph@4.0.0:
+    resolution: {integrity: sha512-I0hojAJfTbSCZy3y6xyK29eayxo14v1bj1VPiDkHjTdz33SV6RdfMz2AHnf4ai62Vng2mN5GkaKahkooBIo9gA==}
 
   react-composer@5.0.3:
     resolution: {integrity: sha512-1uWd07EME6XZvMfapwZmc7NgCZqDemcvicRi3wMJzXsQLvZ3L7fTHVyPy1bZdnWXM4iPjYuNE+uJ41MLKeTtnA==}
@@ -1370,6 +1568,15 @@ packages:
 
   scheduler@0.27.0:
     resolution: {integrity: sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==}
+
+  semver@7.7.4:
+    resolution: {integrity: sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==}
+    engines: {node: '>=10'}
+    hasBin: true
+
+  sharp@0.34.5:
+    resolution: {integrity: sha512-Ou9I5Ft9WNcCbXrU9cMgPBcCK8LiwLqcbywW3t4oDV37n1pzpuNLsYiAV8eODnjbtQlSDwZ2cUEeQz4E54Hltg==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
 
   shebang-command@2.0.0:
     resolution: {integrity: sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==}
@@ -1481,6 +1688,9 @@ packages:
 
   undici-types@6.21.0:
     resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
+
+  uniq@1.0.1:
+    resolution: {integrity: sha512-Gw+zz50YNKPDKXs+9d+aKAjVwpjNwqzvNpLigIruT4HA9lMZNdMqs9x07kKHB/L9WRzqp4+DlTU5s4wG2esdoA==}
 
   use-sync-external-store@1.6.0:
     resolution: {integrity: sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==}
@@ -2160,6 +2370,11 @@ snapshots:
 
   '@babel/runtime@7.28.6': {}
 
+  '@emnapi/runtime@1.8.1':
+    dependencies:
+      tslib: 2.8.1
+    optional: true
+
   '@esbuild/aix-ppc64@0.21.5':
     optional: true
 
@@ -2305,6 +2520,120 @@ snapshots:
     optional: true
 
   '@esbuild/win32-x64@0.25.12':
+    optional: true
+
+  '@gltf-transform/core@4.3.0':
+    dependencies:
+      property-graph: 4.0.0
+
+  '@gltf-transform/extensions@4.3.0':
+    dependencies:
+      '@gltf-transform/core': 4.3.0
+      ktx-parse: 1.1.0
+
+  '@gltf-transform/functions@4.3.0':
+    dependencies:
+      '@gltf-transform/core': 4.3.0
+      '@gltf-transform/extensions': 4.3.0
+      ktx-parse: 1.1.0
+      ndarray: 1.0.19
+      ndarray-lanczos: 0.3.0
+      ndarray-pixels: 5.0.1
+
+  '@img/colour@1.0.0': {}
+
+  '@img/sharp-darwin-arm64@0.34.5':
+    optionalDependencies:
+      '@img/sharp-libvips-darwin-arm64': 1.2.4
+    optional: true
+
+  '@img/sharp-darwin-x64@0.34.5':
+    optionalDependencies:
+      '@img/sharp-libvips-darwin-x64': 1.2.4
+    optional: true
+
+  '@img/sharp-libvips-darwin-arm64@1.2.4':
+    optional: true
+
+  '@img/sharp-libvips-darwin-x64@1.2.4':
+    optional: true
+
+  '@img/sharp-libvips-linux-arm64@1.2.4':
+    optional: true
+
+  '@img/sharp-libvips-linux-arm@1.2.4':
+    optional: true
+
+  '@img/sharp-libvips-linux-ppc64@1.2.4':
+    optional: true
+
+  '@img/sharp-libvips-linux-riscv64@1.2.4':
+    optional: true
+
+  '@img/sharp-libvips-linux-s390x@1.2.4':
+    optional: true
+
+  '@img/sharp-libvips-linux-x64@1.2.4':
+    optional: true
+
+  '@img/sharp-libvips-linuxmusl-arm64@1.2.4':
+    optional: true
+
+  '@img/sharp-libvips-linuxmusl-x64@1.2.4':
+    optional: true
+
+  '@img/sharp-linux-arm64@0.34.5':
+    optionalDependencies:
+      '@img/sharp-libvips-linux-arm64': 1.2.4
+    optional: true
+
+  '@img/sharp-linux-arm@0.34.5':
+    optionalDependencies:
+      '@img/sharp-libvips-linux-arm': 1.2.4
+    optional: true
+
+  '@img/sharp-linux-ppc64@0.34.5':
+    optionalDependencies:
+      '@img/sharp-libvips-linux-ppc64': 1.2.4
+    optional: true
+
+  '@img/sharp-linux-riscv64@0.34.5':
+    optionalDependencies:
+      '@img/sharp-libvips-linux-riscv64': 1.2.4
+    optional: true
+
+  '@img/sharp-linux-s390x@0.34.5':
+    optionalDependencies:
+      '@img/sharp-libvips-linux-s390x': 1.2.4
+    optional: true
+
+  '@img/sharp-linux-x64@0.34.5':
+    optionalDependencies:
+      '@img/sharp-libvips-linux-x64': 1.2.4
+    optional: true
+
+  '@img/sharp-linuxmusl-arm64@0.34.5':
+    optionalDependencies:
+      '@img/sharp-libvips-linuxmusl-arm64': 1.2.4
+    optional: true
+
+  '@img/sharp-linuxmusl-x64@0.34.5':
+    optionalDependencies:
+      '@img/sharp-libvips-linuxmusl-x64': 1.2.4
+    optional: true
+
+  '@img/sharp-wasm32@0.34.5':
+    dependencies:
+      '@emnapi/runtime': 1.8.1
+    optional: true
+
+  '@img/sharp-win32-arm64@0.34.5':
+    optional: true
+
+  '@img/sharp-win32-ia32@0.34.5':
+    optional: true
+
+  '@img/sharp-win32-x64@0.34.5':
     optional: true
 
   '@isaacs/cliui@9.0.0': {}
@@ -2827,6 +3156,8 @@ snapshots:
 
   '@types/mime-types@2.1.4': {}
 
+  '@types/ndarray@1.0.14': {}
+
   '@types/node@22.19.11':
     dependencies:
       undici-types: 6.21.0
@@ -2963,6 +3294,10 @@ snapshots:
 
   csstype@3.2.3: {}
 
+  cwise-compiler@1.1.3:
+    dependencies:
+      uniq: 1.0.1
+
   debug@4.4.3:
     dependencies:
       ms: 2.1.3
@@ -2973,7 +3308,11 @@ snapshots:
     dependencies:
       webgl-constants: 1.1.1
 
+  detect-libc@2.1.2: {}
+
   draco3d@1.5.7: {}
+
+  draco3dgltf@1.5.7: {}
 
   entities@7.0.1: {}
 
@@ -3093,6 +3432,10 @@ snapshots:
 
   inherits@2.0.4: {}
 
+  iota-array@1.0.0: {}
+
+  is-buffer@1.1.6: {}
+
   is-promise@2.2.2: {}
 
   isexe@2.0.0: {}
@@ -3109,6 +3452,8 @@ snapshots:
       '@isaacs/cliui': 9.0.0
 
   js-tokens@4.0.0: {}
+
+  ktx-parse@1.1.0: {}
 
   lie@3.3.0:
     dependencies:
@@ -3153,6 +3498,27 @@ snapshots:
 
   nanoid@3.3.11: {}
 
+  ndarray-lanczos@0.3.0:
+    dependencies:
+      '@types/ndarray': 1.0.14
+      ndarray: 1.0.19
+
+  ndarray-ops@1.2.2:
+    dependencies:
+      cwise-compiler: 1.1.3
+
+  ndarray-pixels@5.0.1:
+    dependencies:
+      '@types/ndarray': 1.0.14
+      ndarray: 1.0.19
+      ndarray-ops: 1.2.2
+      sharp: 0.34.5
+
+  ndarray@1.0.19:
+    dependencies:
+      iota-array: 1.0.0
+      is-buffer: 1.1.6
+
   object-assign@4.1.1: {}
 
   package-json-from-dist@1.0.1: {}
@@ -3190,6 +3556,8 @@ snapshots:
       loose-envify: 1.4.0
       object-assign: 4.1.1
       react-is: 16.13.1
+
+  property-graph@4.0.0: {}
 
   react-composer@5.0.3(react@19.2.4):
     dependencies:
@@ -3253,6 +3621,39 @@ snapshots:
   safe-buffer@5.2.1: {}
 
   scheduler@0.27.0: {}
+
+  semver@7.7.4: {}
+
+  sharp@0.34.5:
+    dependencies:
+      '@img/colour': 1.0.0
+      detect-libc: 2.1.2
+      semver: 7.7.4
+    optionalDependencies:
+      '@img/sharp-darwin-arm64': 0.34.5
+      '@img/sharp-darwin-x64': 0.34.5
+      '@img/sharp-libvips-darwin-arm64': 1.2.4
+      '@img/sharp-libvips-darwin-x64': 1.2.4
+      '@img/sharp-libvips-linux-arm': 1.2.4
+      '@img/sharp-libvips-linux-arm64': 1.2.4
+      '@img/sharp-libvips-linux-ppc64': 1.2.4
+      '@img/sharp-libvips-linux-riscv64': 1.2.4
+      '@img/sharp-libvips-linux-s390x': 1.2.4
+      '@img/sharp-libvips-linux-x64': 1.2.4
+      '@img/sharp-libvips-linuxmusl-arm64': 1.2.4
+      '@img/sharp-libvips-linuxmusl-x64': 1.2.4
+      '@img/sharp-linux-arm': 0.34.5
+      '@img/sharp-linux-arm64': 0.34.5
+      '@img/sharp-linux-ppc64': 0.34.5
+      '@img/sharp-linux-riscv64': 0.34.5
+      '@img/sharp-linux-s390x': 0.34.5
+      '@img/sharp-linux-x64': 0.34.5
+      '@img/sharp-linuxmusl-arm64': 0.34.5
+      '@img/sharp-linuxmusl-x64': 0.34.5
+      '@img/sharp-wasm32': 0.34.5
+      '@img/sharp-win32-arm64': 0.34.5
+      '@img/sharp-win32-ia32': 0.34.5
+      '@img/sharp-win32-x64': 0.34.5
 
   shebang-command@2.0.0:
     dependencies:
@@ -3350,6 +3751,8 @@ snapshots:
   typescript@5.9.3: {}
 
   undici-types@6.21.0: {}
+
+  uniq@1.0.1: {}
 
   use-sync-external-store@1.6.0(react@19.2.4):
     dependencies:

--- a/static3d.config.json
+++ b/static3d.config.json
@@ -2,6 +2,13 @@
   "schemaVersion": 1,
   "project": "my-cake-shop",
 
+  "optimize": {
+    "enabled": true,
+    "draco": true,
+    "prune": true,
+    "dedup": true
+  },
+
   "deploy": {
     "pages": {
       "outputDir": "dist/pages",


### PR DESCRIPTION
## 概要

@static3d/deploy のビルドパイプラインに glTF-Transform を統合し、GLB/glTF ファイルを自動圧縮する機能を追加。

## 変更内容

### 新規ファイル

| ファイル | 内容 |
|----------|------|
| `packages/deploy/src/build/optimize.ts` | `optimizeGlb` / `optimizeAsset` ― NodeIO + KHRDracoMeshCompression を使った最適化パイプライン |
| `packages/deploy/src/config/optimize-config.ts` | `OptimizeConfig` 型 + `extractOptimizeConfig()` ― `@static3d/types` を変更せずに設定を拡張 |
| `packages/deploy/src/types/draco3dgltf.d.ts` | `draco3dgltf` の ambient 型宣言（公式 @types なし） |
| `packages/deploy/src/tests/optimize.test.ts` | 37 ユニットテスト |

### 更新ファイル

| ファイル | 内容 |
|----------|------|
| `packages/deploy/src/build/index.ts` | Step 0: hash より前に `optimizeAsset` を実行；最適化済みバッファを tmp に書き出してパスを差し替え |
| `packages/deploy/package.json` | `@gltf-transform/{core,extensions,functions}`, `draco3dgltf` を dependencies に追加 |
| `static3d.config.json` | `optimize` ブロック追加: `{enabled,draco,prune,dedup}` |

## 技術詳細

- Draco encoder は `draco()函数` に直接渡すのではなく `io.registerDependencies({'draco3d.encoder': module})` 経由で登録（gltf-transform 4.x API に準拠）
- 変換順: `dedup → prune → draco`（各フラグで個別に on/off）
- ログ例: `[OPTIMIZE] bakery_shop.glb: 6.4MB → 2.1MB (-67%)`
- `optimize.enabled=false` のときはパイプラインをスキップし既存動作を維持

## テスト

- `pnpm -r build` ✅ TypeScript エラー 0
- `pnpm -r test` ✅
  - `@static3d/deploy`: 11 files, **111 tests** passed (うち新規 37)
  - `@static3d/display`: 5 files, **100 tests** passed
  - 合計: **211 tests** passed

## 制約確認

- ✅ `@static3d/types` および `@static3d/display` パッケージは変更なし
- ✅ 変更は `packages/deploy` のみ（+ `static3d.config.json`）
- ✅ 新規 npm 依存追加 (`@gltf-transform/*`, `draco3dgltf`) — 要件で明示許可